### PR TITLE
Migrate from icu_locid to icu_locale_core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.3.0
+
+**Breaking:** Replaced `icu_locid` and `fluent-langneg` dependencies with `icu_locale_core` 2.1. The re-exported `LanguageIdentifier` type is now from `icu_locale_core` instead of `icu_locid`.
+
+## 0.2.9 and earlier
+
+See [git history](https://github.com/human-solutions/fluent-typed/commits/main).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,5 +28,5 @@ unic-langid = "0.9"
 icu_locale_core = { version = "2.1", optional = true, features = ["alloc"] }
 
 [dev-dependencies]
-insta = "1.42"
+insta = "1.46"
 unic-langid = { version = "0.9", features = ["macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ langneg = ["dep:icu_locale_core"]
 fluent-syntax = "0.12"
 fluent-bundle = "0.16"
 unic-langid = "0.9"
-icu_locale_core = { version = "2.0", optional = true, features = ["alloc"] }
+icu_locale_core = { version = "2.1", optional = true, features = ["alloc"] }
 
 [dev-dependencies]
 insta = "1.42"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluent-typed"
-version = "0.2.9"
+version = "0.3.0"
 edition = "2024"
 description = "Type-safe access to Fluent localization messages"
 keywords = ["fluent", "internationalization", "localization"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,14 +19,13 @@ doctest = false
 # When developing, make sure that the default is un-commented.
 default = ["build", "langneg"]
 build = []
-langneg = ["dep:fluent-langneg", "dep:icu_locid"]
+langneg = ["dep:icu_locale_core"]
 
 [dependencies]
 fluent-syntax = "0.12"
 fluent-bundle = "0.16"
-fluent-langneg = { version = "0.14.1", optional = true }
 unic-langid = "0.9"
-icu_locid = { version = "1.5", optional = true }
+icu_locale_core = { version = "2.0", optional = true, features = ["alloc"] }
 
 [dev-dependencies]
 insta = "1.42"

--- a/playground/example1/src/multi_l10n.rs
+++ b/playground/example1/src/multi_l10n.rs
@@ -101,7 +101,7 @@ pub struct L10nLanguage(L10nBundle);
 
 impl L10nLanguage {
     /// Load the L10n resources for the given language. The language
-    /// has to be a valid unic_langid::LanguageIdentifier or otherwise
+    /// has to be a valid LanguageIdentifier or otherwise
     /// an error is returned.
     ///
     /// The bytes are expected to be the contents of a .ftl file

--- a/playground/example1/src/single_gzip_l10n.rs
+++ b/playground/example1/src/single_gzip_l10n.rs
@@ -133,7 +133,7 @@ pub struct L10nLanguage(L10nBundle);
 
 impl L10nLanguage {
     /// Load the L10n resources for the given language. The language
-    /// has to be a valid unic_langid::LanguageIdentifier or otherwise
+    /// has to be a valid LanguageIdentifier or otherwise
     /// an error is returned.
     ///
     /// The bytes are expected to be the contents of a .ftl file

--- a/playground/example1/src/single_l10n.rs
+++ b/playground/example1/src/single_l10n.rs
@@ -124,7 +124,7 @@ pub struct L10nLanguage(L10nBundle);
 
 impl L10nLanguage {
     /// Load the L10n resources for the given language. The language
-    /// has to be a valid unic_langid::LanguageIdentifier or otherwise
+    /// has to be a valid LanguageIdentifier or otherwise
     /// an error is returned.
     ///
     /// The bytes are expected to be the contents of a .ftl file

--- a/src/build/gen/template.rs
+++ b/src/build/gen/template.rs
@@ -74,7 +74,7 @@ pub struct L10nLanguage(L10nBundle);
 
 impl L10nLanguage {
     /// Load the L10n resources for the given language. The language
-    /// has to be a valid unic_langid::LanguageIdentifier or otherwise
+    /// has to be a valid LanguageIdentifier or otherwise
     /// an error is returned.
     ///
     /// The bytes are expected to be the contents of a .ftl file

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,21 +17,44 @@ pub mod prelude {
     pub use crate::l10n_language_vec::L10nLanguageVec;
     pub use fluent_bundle::{types::FluentNumber, FluentArgs, FluentValue};
     #[cfg(feature = "langneg")]
-    pub use icu_locid::{langid, LanguageIdentifier};
+    pub use icu_locale_core::{langid, LanguageIdentifier};
 
     #[cfg(feature = "langneg")]
     pub fn negotiate_languages<'a, A>(accept_language: &str, available: &'a [A]) -> A
     where
         A: 'a + AsRef<LanguageIdentifier> + PartialEq + Default + Copy,
     {
-        use fluent_langneg::{
-            negotiate_languages, parse_accepted_languages, NegotiationStrategy::Filtering,
-        };
-        let requested = parse_accepted_languages(accept_language);
+        // Parse Accept-Language header into (LanguageIdentifier, quality) pairs, sorted by quality descending
+        let mut requested: Vec<(LanguageIdentifier, u16)> = accept_language
+            .split(',')
+            .filter_map(|entry| {
+                let entry = entry.trim();
+                if entry.is_empty() {
+                    return None;
+                }
+                let (tag, quality) = if let Some((tag, params)) = entry.split_once(';') {
+                    let q = params
+                        .trim()
+                        .strip_prefix("q=")
+                        .and_then(|v| v.parse::<f32>().ok())
+                        .unwrap_or(1.0);
+                    (tag.trim(), (q * 1000.0) as u16)
+                } else {
+                    (entry, 1000)
+                };
+                tag.parse::<LanguageIdentifier>().ok().map(|lid| (lid, quality))
+            })
+            .collect();
+        requested.sort_by(|a, b| b.1.cmp(&a.1));
 
-        negotiate_languages(&requested, available, None, Filtering)
-            .first()
-            .map(|l| **l)
-            .unwrap_or_default()
+        // Find the first available language whose language subtag matches a requested one
+        for (req, _) in &requested {
+            for avail in available {
+                if avail.as_ref().language == req.language {
+                    return *avail;
+                }
+            }
+        }
+        A::default()
     }
 }

--- a/src/tests/gen/attrib_only_gen.rs
+++ b/src/tests/gen/attrib_only_gen.rs
@@ -109,7 +109,7 @@ pub struct L10nLanguage(L10nBundle);
 
 impl L10nLanguage {
     /// Load the L10n resources for the given language. The language
-    /// has to be a valid unic_langid::LanguageIdentifier or otherwise
+    /// has to be a valid LanguageIdentifier or otherwise
     /// an error is returned.
     ///
     /// The bytes are expected to be the contents of a .ftl file

--- a/src/tests/gen/complex_gen.rs
+++ b/src/tests/gen/complex_gen.rs
@@ -109,7 +109,7 @@ pub struct L10nLanguage(L10nBundle);
 
 impl L10nLanguage {
     /// Load the L10n resources for the given language. The language
-    /// has to be a valid unic_langid::LanguageIdentifier or otherwise
+    /// has to be a valid LanguageIdentifier or otherwise
     /// an error is returned.
     ///
     /// The bytes are expected to be the contents of a .ftl file

--- a/src/tests/gen/msg_number_gen.rs
+++ b/src/tests/gen/msg_number_gen.rs
@@ -109,7 +109,7 @@ pub struct L10nLanguage(L10nBundle);
 
 impl L10nLanguage {
     /// Load the L10n resources for the given language. The language
-    /// has to be a valid unic_langid::LanguageIdentifier or otherwise
+    /// has to be a valid LanguageIdentifier or otherwise
     /// an error is returned.
     ///
     /// The bytes are expected to be the contents of a .ftl file

--- a/src/tests/gen/msg_string_gen.rs
+++ b/src/tests/gen/msg_string_gen.rs
@@ -109,7 +109,7 @@ pub struct L10nLanguage(L10nBundle);
 
 impl L10nLanguage {
     /// Load the L10n resources for the given language. The language
-    /// has to be a valid unic_langid::LanguageIdentifier or otherwise
+    /// has to be a valid LanguageIdentifier or otherwise
     /// an error is returned.
     ///
     /// The bytes are expected to be the contents of a .ftl file

--- a/src/tests/gen/msg_text_gen.rs
+++ b/src/tests/gen/msg_text_gen.rs
@@ -109,7 +109,7 @@ pub struct L10nLanguage(L10nBundle);
 
 impl L10nLanguage {
     /// Load the L10n resources for the given language. The language
-    /// has to be a valid unic_langid::LanguageIdentifier or otherwise
+    /// has to be a valid LanguageIdentifier or otherwise
     /// an error is returned.
     ///
     /// The bytes are expected to be the contents of a .ftl file

--- a/src/tests/gen/msg_with_attrib_gen.rs
+++ b/src/tests/gen/msg_with_attrib_gen.rs
@@ -109,7 +109,7 @@ pub struct L10nLanguage(L10nBundle);
 
 impl L10nLanguage {
     /// Load the L10n resources for the given language. The language
-    /// has to be a valid unic_langid::LanguageIdentifier or otherwise
+    /// has to be a valid LanguageIdentifier or otherwise
     /// an error is returned.
     ///
     /// The bytes are expected to be the contents of a .ftl file

--- a/src/tests/gen/msg_with_var_gen.rs
+++ b/src/tests/gen/msg_with_var_gen.rs
@@ -109,7 +109,7 @@ pub struct L10nLanguage(L10nBundle);
 
 impl L10nLanguage {
     /// Load the L10n resources for the given language. The language
-    /// has to be a valid unic_langid::LanguageIdentifier or otherwise
+    /// has to be a valid LanguageIdentifier or otherwise
     /// an error is returned.
     ///
     /// The bytes are expected to be the contents of a .ftl file

--- a/src/tests/gen/res_msg_text_gen.rs
+++ b/src/tests/gen/res_msg_text_gen.rs
@@ -109,7 +109,7 @@ pub struct L10nLanguage(L10nBundle);
 
 impl L10nLanguage {
     /// Load the L10n resources for the given language. The language
-    /// has to be a valid unic_langid::LanguageIdentifier or otherwise
+    /// has to be a valid LanguageIdentifier or otherwise
     /// an error is returned.
     ///
     /// The bytes are expected to be the contents of a .ftl file

--- a/src/tests/gen/test_format_generated_rust_file_gen.rs
+++ b/src/tests/gen/test_format_generated_rust_file_gen.rs
@@ -116,7 +116,7 @@ pub struct L10nLanguage(L10nBundle);
 
 impl L10nLanguage {
     /// Load the L10n resources for the given language. The language
-    /// has to be a valid unic_langid::LanguageIdentifier or otherwise
+    /// has to be a valid LanguageIdentifier or otherwise
     /// an error is returned.
     ///
     /// The bytes are expected to be the contents of a .ftl file

--- a/src/tests/gen/test_locales_deep_folders_gen.rs
+++ b/src/tests/gen/test_locales_deep_folders_gen.rs
@@ -124,7 +124,7 @@ pub struct L10nLanguage(L10nBundle);
 
 impl L10nLanguage {
     /// Load the L10n resources for the given language. The language
-    /// has to be a valid unic_langid::LanguageIdentifier or otherwise
+    /// has to be a valid LanguageIdentifier or otherwise
     /// an error is returned.
     ///
     /// The bytes are expected to be the contents of a .ftl file

--- a/src/tests/gen/test_locales_gen.rs
+++ b/src/tests/gen/test_locales_gen.rs
@@ -116,7 +116,7 @@ pub struct L10nLanguage(L10nBundle);
 
 impl L10nLanguage {
     /// Load the L10n resources for the given language. The language
-    /// has to be a valid unic_langid::LanguageIdentifier or otherwise
+    /// has to be a valid LanguageIdentifier or otherwise
     /// an error is returned.
     ///
     /// The bytes are expected to be the contents of a .ftl file

--- a/src/tests/gen/test_locales_missing_msg_gen.rs
+++ b/src/tests/gen/test_locales_missing_msg_gen.rs
@@ -116,7 +116,7 @@ pub struct L10nLanguage(L10nBundle);
 
 impl L10nLanguage {
     /// Load the L10n resources for the given language. The language
-    /// has to be a valid unic_langid::LanguageIdentifier or otherwise
+    /// has to be a valid LanguageIdentifier or otherwise
     /// an error is returned.
     ///
     /// The bytes are expected to be the contents of a .ftl file

--- a/src/tests/gen/test_locales_multi_resources_gen.rs
+++ b/src/tests/gen/test_locales_multi_resources_gen.rs
@@ -116,7 +116,7 @@ pub struct L10nLanguage(L10nBundle);
 
 impl L10nLanguage {
     /// Load the L10n resources for the given language. The language
-    /// has to be a valid unic_langid::LanguageIdentifier or otherwise
+    /// has to be a valid LanguageIdentifier or otherwise
     /// an error is returned.
     ///
     /// The bytes are expected to be the contents of a .ftl file

--- a/src/tests/gen/test_unformated_generated_rust_file_gen.rs
+++ b/src/tests/gen/test_unformated_generated_rust_file_gen.rs
@@ -116,7 +116,7 @@ pub struct L10nLanguage(L10nBundle);
 
 impl L10nLanguage {
     /// Load the L10n resources for the given language. The language
-    /// has to be a valid unic_langid::LanguageIdentifier or otherwise
+    /// has to be a valid LanguageIdentifier or otherwise
     /// an error is returned.
     ///
     /// The bytes are expected to be the contents of a .ftl file

--- a/src/tests/snapshots/fluent_typed__tests__format_generated_rust_file-2.snap
+++ b/src/tests/snapshots/fluent_typed__tests__format_generated_rust_file-2.snap
@@ -120,7 +120,7 @@ pub struct L10nLanguage(L10nBundle);
 
 impl L10nLanguage {
     /// Load the L10n resources for the given language. The language
-    /// has to be a valid unic_langid::LanguageIdentifier or otherwise
+    /// has to be a valid LanguageIdentifier or otherwise
     /// an error is returned.
     ///
     /// The bytes are expected to be the contents of a .ftl file

--- a/src/tests/snapshots/fluent_typed__tests__format_generated_rust_file.snap
+++ b/src/tests/snapshots/fluent_typed__tests__format_generated_rust_file.snap
@@ -120,7 +120,7 @@ pub struct L10nLanguage(L10nBundle);
 
 impl L10nLanguage {
     /// Load the L10n resources for the given language. The language
-    /// has to be a valid unic_langid::LanguageIdentifier or otherwise
+    /// has to be a valid LanguageIdentifier or otherwise
     /// an error is returned.
     ///
     /// The bytes are expected to be the contents of a .ftl file


### PR DESCRIPTION
## Summary
- Replace deprecated `icu_locid` 1.5 and `fluent-langneg` 0.14 with `icu_locale_core` 2.0 (the successor crate)
- Replace `fluent-langneg` dependency with inline Accept-Language parsing and language negotiation
- Update stale doc comment referencing `unic_langid::LanguageIdentifier`

## Motivation
Dependabot PR #10 bumped `icu_locid` from 1.5 to 2.0, but `icu_locid` 2.0 is a deprecated empty shim — the real crate is now `icu_locale_core`. Additionally, `fluent-langneg` 0.14.x depends on `icu_locid ^1.4` and hasn't been updated, so it needed to be replaced too.

## Changes
- **Cargo.toml**: Replace `icu_locid` and `fluent-langneg` dependencies with `icu_locale_core` 2.0
- **src/lib.rs**: Rewrite `negotiate_languages` with inline Accept-Language parsing and language subtag matching
- **src/build/gen/template.rs**: Fix stale doc comment
- Generated files and snapshots updated accordingly

## Test plan
- [x] `cargo build` (default features)
- [x] `cargo build --no-default-features --features build`
- [x] `cargo build --no-default-features --features langneg`
- [x] `cargo build --features build,langneg`
- [x] `cargo test` — all 42 tests pass
- [x] `cargo clippy` — no new warnings

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)