### PR TITLE
Add BuildError enum and duplicate key validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.5.0
+
+### Added
+- `BuildError` enum for structured, inspectable build errors with proper
+  `Display` and `Error` trait implementations.
+- Duplicate message key detection across FTL files within the same language,
+  enabled by default. Disable with `BuildOptions::with_allow_duplicate_keys()`.
+
+### Changed
+- **Breaking:** All public build functions now return `Result<_, BuildError>`
+  instead of `Result<_, String>`. Callers using `map_err` or matching on
+  `String` errors must update to use `BuildError`.
+- **Breaking:** `BuildOptions` has a new `deny_duplicate_keys` field
+  (default `true`). Direct struct construction must include this field;
+  `BuildOptions::default()` users are unaffected.
+
 ## 0.4.0
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluent-typed"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 description = "Type-safe access to Fluent localization messages"
 keywords = ["fluent", "internationalization", "localization"]

--- a/playground/example1/build.rs
+++ b/playground/example1/build.rs
@@ -1,5 +1,5 @@
 use flate2::{write::GzEncoder, Compression};
-use fluent_typed::{try_build_from_locales_folder, BuildOptions, FtlOutputOptions};
+use fluent_typed::{BuildError, try_build_from_locales_folder, BuildOptions, FtlOutputOptions};
 use std::io::Write;
 use std::process::ExitCode;
 
@@ -13,7 +13,7 @@ fn main() -> ExitCode {
     }
 }
 
-fn try_main() -> Result<(), String> {
+fn try_main() -> Result<(), BuildError> {
     let multi_opts = BuildOptions::default()
         .with_ftl_output(FtlOutputOptions::MultiFile {
             output_ftl_folder: "gen/multi/".to_string(),

--- a/src/build/builder.rs
+++ b/src/build/builder.rs
@@ -11,13 +11,7 @@ impl Builder {
         let folder = &options.locales_folder;
         println!("cargo::rerun-if-changed={folder}");
 
-        let mut langbundles =
-            from_locales_folder(folder, options.deny_duplicate_keys).map_err(|e| {
-                BuildError::LocalesFolder {
-                    folder: folder.to_string(),
-                    source: Box::new(e),
-                }
-            })?;
+        let mut langbundles = from_locales_folder(folder, options.deny_duplicate_keys)?;
 
         langbundles.sort_by_cached_key(|lb| lb.language_id.clone());
 
@@ -101,10 +95,14 @@ fn from_locales_folder(
     folder: &str,
     deny_duplicate_keys: bool,
 ) -> Result<Vec<LangBundle>, BuildError> {
-    let locales_dir = fs::read_dir(folder)?;
+    let map_io = |e| BuildError::LocalesFolder {
+        folder: folder.to_string(),
+        source: e,
+    };
+    let locales_dir = fs::read_dir(folder).map_err(map_io)?;
     let mut locales = Vec::new();
     for entry in locales_dir {
-        let entry = entry?;
+        let entry = entry.map_err(map_io)?;
         let path = entry.path();
         if path.is_dir() {
             let lang = path.file_name().unwrap().to_str().unwrap();

--- a/src/build/builder.rs
+++ b/src/build/builder.rs
@@ -56,10 +56,10 @@ impl Builder {
             .replace("    ", &self.options.indentation);
 
         let output_file_path = &self.options.output_file_path;
-        if let Some(current_file) = fs::read_to_string(output_file_path).ok() {
-            if current_file == generated {
-                return Ok(());
-            }
+        if let Ok(current_file) = fs::read_to_string(output_file_path)
+            && current_file == generated
+        {
+            return Ok(());
         }
 
         fs::write(output_file_path, &generated).map_err(|e| BuildError::WriteOutput {

--- a/src/build/error.rs
+++ b/src/build/error.rs
@@ -1,10 +1,14 @@
-use std::{error::Error, fmt, io};
+use std::{error::Error, fmt, io, path::PathBuf};
 
 #[derive(Debug)]
 pub enum BuildError {
     FtlParse(String),
     Io(io::Error),
-    DuplicateKey(String),
+    DuplicateKey {
+        key: String,
+        original: PathBuf,
+        duplicate: PathBuf,
+    },
     LocalesFolder {
         folder: String,
         source: Box<BuildError>,
@@ -22,7 +26,16 @@ impl fmt::Display for BuildError {
         match self {
             Self::FtlParse(msg) => write!(f, "Could not parse ftl: {msg}"),
             Self::Io(err) => write!(f, "{err}"),
-            Self::DuplicateKey(key) => write!(f, "Duplicate message key '{key}'"),
+            Self::DuplicateKey {
+                key,
+                original,
+                duplicate,
+            } => write!(
+                f,
+                "Duplicate message key '{key}' in '{}', first defined in '{}'",
+                duplicate.display(),
+                original.display()
+            ),
             Self::LocalesFolder { folder, source } => {
                 write!(f, "Could not read locales folder '{folder}': {source}")
             }

--- a/src/build/error.rs
+++ b/src/build/error.rs
@@ -1,0 +1,53 @@
+use std::{error::Error, fmt, io};
+
+#[derive(Debug)]
+pub enum BuildError {
+    FtlParse(String),
+    Io(io::Error),
+    DuplicateKey(String),
+    LocalesFolder {
+        folder: String,
+        source: Box<BuildError>,
+    },
+    WriteOutput {
+        path: String,
+        source: io::Error,
+    },
+    Rustfmt(String),
+    Generation(String),
+}
+
+impl fmt::Display for BuildError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::FtlParse(msg) => write!(f, "Could not parse ftl: {msg}"),
+            Self::Io(err) => write!(f, "{err}"),
+            Self::DuplicateKey(key) => write!(f, "Duplicate message key '{key}'"),
+            Self::LocalesFolder { folder, source } => {
+                write!(f, "Could not read locales folder '{folder}': {source}")
+            }
+            Self::WriteOutput { path, source } => {
+                write!(f, "Could not write file '{path}': {source}")
+            }
+            Self::Rustfmt(msg) => write!(f, "Rustfmt error: {msg}"),
+            Self::Generation(msg) => write!(f, "{msg}"),
+        }
+    }
+}
+
+impl Error for BuildError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Io(err) => Some(err),
+            Self::LocalesFolder { source, .. } => Some(source.as_ref()),
+            Self::WriteOutput { source, .. } => Some(source),
+            _ => None,
+        }
+    }
+}
+
+impl From<io::Error> for BuildError {
+    fn from(err: io::Error) -> Self {
+        Self::Io(err)
+    }
+}

--- a/src/build/error.rs
+++ b/src/build/error.rs
@@ -3,7 +3,10 @@ use std::{error::Error, fmt, io, path::PathBuf};
 #[derive(Debug)]
 pub enum BuildError {
     FtlParse(String),
-    Io(io::Error),
+    FtlRead {
+        path: PathBuf,
+        source: io::Error,
+    },
     DuplicateKey {
         key: String,
         original: PathBuf,
@@ -11,7 +14,7 @@ pub enum BuildError {
     },
     LocalesFolder {
         folder: String,
-        source: Box<BuildError>,
+        source: io::Error,
     },
     WriteOutput {
         path: String,
@@ -25,17 +28,29 @@ impl fmt::Display for BuildError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::FtlParse(msg) => write!(f, "Could not parse ftl: {msg}"),
-            Self::Io(err) => write!(f, "{err}"),
+            Self::FtlRead { path, .. } => {
+                write!(f, "Could not read '{}'", path.display())
+            }
             Self::DuplicateKey {
                 key,
                 original,
                 duplicate,
-            } => write!(
-                f,
-                "Duplicate message key '{key}' in '{}', first defined in '{}'",
-                duplicate.display(),
-                original.display()
-            ),
+            } => {
+                if original == duplicate {
+                    write!(
+                        f,
+                        "Duplicate message key '{key}' in '{}'",
+                        duplicate.display()
+                    )
+                } else {
+                    write!(
+                        f,
+                        "Duplicate message key '{key}' in '{}', first defined in '{}'",
+                        duplicate.display(),
+                        original.display()
+                    )
+                }
+            }
             Self::LocalesFolder { folder, .. } => {
                 write!(f, "Could not read locales folder '{folder}'")
             }
@@ -51,16 +66,10 @@ impl fmt::Display for BuildError {
 impl Error for BuildError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
-            Self::Io(err) => Some(err),
-            Self::LocalesFolder { source, .. } => Some(source.as_ref()),
+            Self::FtlRead { source, .. } => Some(source),
+            Self::LocalesFolder { source, .. } => Some(source),
             Self::WriteOutput { source, .. } => Some(source),
             _ => None,
         }
-    }
-}
-
-impl From<io::Error> for BuildError {
-    fn from(err: io::Error) -> Self {
-        Self::Io(err)
     }
 }

--- a/src/build/error.rs
+++ b/src/build/error.rs
@@ -36,11 +36,11 @@ impl fmt::Display for BuildError {
                 duplicate.display(),
                 original.display()
             ),
-            Self::LocalesFolder { folder, source } => {
-                write!(f, "Could not read locales folder '{folder}': {source}")
+            Self::LocalesFolder { folder, .. } => {
+                write!(f, "Could not read locales folder '{folder}'")
             }
-            Self::WriteOutput { path, source } => {
-                write!(f, "Could not write file '{path}': {source}")
+            Self::WriteOutput { path, .. } => {
+                write!(f, "Could not write file '{path}'")
             }
             Self::Rustfmt(msg) => write!(f, "Rustfmt error: {msg}"),
             Self::Generation(msg) => write!(f, "{msg}"),

--- a/src/build/gen/generated_ftl.rs
+++ b/src/build/gen/generated_ftl.rs
@@ -76,7 +76,7 @@ impl GeneratedFtl {
 "#
         };
 
-        out.push_str(&load_fn);
+        out.push_str(load_fn);
 
         let load_all_fn = if compressed {
             r#"
@@ -106,7 +106,7 @@ impl GeneratedFtl {
     }"#
         };
 
-        out.push_str(&load_all_fn);
+        out.push_str(load_all_fn);
         out
     }
 }
@@ -177,7 +177,7 @@ fn relative(from_path: &Path, to_path: &Path) -> io::Result<PathBuf> {
     let mut to = to_path.components().collect::<VecDeque<_>>();
 
     // Remove common components
-    while let (Some(fr_comp), Some(to_comp)) = (from.get(0), to.get(0)) {
+    while let (Some(fr_comp), Some(to_comp)) = (from.front(), to.front()) {
         if fr_comp != to_comp {
             break;
         }

--- a/src/build/gen/message.rs
+++ b/src/build/gen/message.rs
@@ -122,10 +122,11 @@ impl Message {
 }
 
 fn lifetime(vars: &[Variable]) -> &'static str {
-    vars.iter()
-        .any(|v| v.typ == VarType::Any)
-        .then_some("'a, ")
-        .unwrap_or_default()
+    if vars.iter().any(|v| v.typ == VarType::Any) {
+        "'a, "
+    } else {
+        ""
+    }
 }
 
 fn args_declaration(vars: &[Variable]) -> ArgInfo {

--- a/src/build/gen/mod.rs
+++ b/src/build/gen/mod.rs
@@ -1,19 +1,19 @@
 mod ext;
 mod generated_ftl;
 mod message;
-#[allow(dead_code, unused_mut, unused_imports)]
+#[allow(dead_code, unused_mut, unused_imports, clippy::derivable_impls)]
 mod template;
 
 use super::{BuildOptions, LangBundle, Message};
 pub use ext::StrExt;
 pub use generated_ftl::GeneratedFtl;
 
-pub fn generate<'a>(
+pub fn generate(
     options: &BuildOptions,
     locales: &[LangBundle],
-    messages: &[&'a Message],
+    messages: &[&Message],
 ) -> Result<String, String> {
-    let generated_ftl = options.ftl_output.generate(&locales)?;
+    let generated_ftl = options.ftl_output.generate(locales)?;
 
     let mut langs = locales
         .iter()
@@ -39,7 +39,7 @@ static ALL_LANGS: [L10n; {}] = [
     // languages as an array
 {enum_entries}
 ];"#,
-        langs.iter().count()
+        langs.len()
     );
     replacements.push(("<<placeholder all_langs>>", all_langs));
 
@@ -172,15 +172,14 @@ static ALL_LANGS: [L10n; {}] = [
     // ///////////////////////////
 
     let langneg_fn = if cfg!(feature = "langneg") {
-        format!(
-            r#"
+        r#"
     /// Negotiate the best language to use based on the `Accept-Language` header.
     ///
     /// Falls back to the default language if none of the languages in the header are available.
-    pub fn langneg(accept_language: &str) -> L10n {{
+    pub fn langneg(accept_language: &str) -> L10n {
         negotiate_languages(accept_language, &ALL_LANGS)
-    }}"#,
-        )
+    }"#
+        .to_string()
     } else {
         String::new()
     };

--- a/src/build/lang_bundle.rs
+++ b/src/build/lang_bundle.rs
@@ -3,9 +3,9 @@ use crate::build::utils::Traversable;
 use super::{BuildError, Message};
 use fluent_syntax::ast::Resource;
 use fluent_syntax::parser;
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug)]
 pub struct LangBundle {
@@ -24,10 +24,12 @@ impl LangBundle {
         deny_duplicate_keys: bool,
     ) -> Result<Self, BuildError> {
         let ast = parser::parse(ftl).map_err(|e| BuildError::FtlParse(format!("{e:?}")))?;
+        let path = PathBuf::from(name);
+        let mut seen = HashMap::new();
         Ok(LangBundle {
             language_name: lang_name(&ast),
             language_id: lang.to_string(),
-            messages: to_messages(name, &ast, deny_duplicate_keys)?,
+            messages: to_messages(name, &ast, deny_duplicate_keys, &mut seen, &path)?,
             ftl: ftl.to_string(),
         })
     }
@@ -49,6 +51,8 @@ impl LangBundle {
 
         paths.sort();
 
+        let mut seen: HashMap<String, PathBuf> = HashMap::new();
+
         for path in paths {
             let ftl = fs::read_to_string(&path)?;
             let ast =
@@ -67,7 +71,7 @@ impl LangBundle {
             bundle.ftl.push_str(&ftl);
             bundle.ftl.push('\n');
 
-            let messages = to_messages(&name, &ast, deny_duplicate_keys)?;
+            let messages = to_messages(&name, &ast, deny_duplicate_keys, &mut seen, &path)?;
             bundle.messages.extend(messages);
         }
         Ok(bundle)
@@ -78,8 +82,9 @@ fn to_messages(
     name: &str,
     ast: &Resource<&str>,
     deny_duplicate_keys: bool,
+    seen: &mut HashMap<String, PathBuf>,
+    path: &Path,
 ) -> Result<Vec<Message>, BuildError> {
-    let mut seen = HashSet::new();
     ast.body
         .iter()
         .filter_map(|entry| match entry {
@@ -88,11 +93,18 @@ fn to_messages(
         })
         .flatten()
         .map(|msg| {
-            if deny_duplicate_keys && !seen.insert(msg.id.clone()) {
-                Err(BuildError::DuplicateKey(msg.id.to_string()))
-            } else {
-                Ok(msg)
+            if deny_duplicate_keys {
+                let key = msg.id.to_string();
+                if let Some(original) = seen.get(&key) {
+                    return Err(BuildError::DuplicateKey {
+                        key,
+                        original: original.clone(),
+                        duplicate: path.to_path_buf(),
+                    });
+                }
+                seen.insert(key, path.to_path_buf());
             }
+            Ok(msg)
         })
         .collect()
 }

--- a/src/build/lang_bundle.rs
+++ b/src/build/lang_bundle.rs
@@ -58,10 +58,10 @@ impl LangBundle {
             let ast =
                 parser::parse(ftl.as_str()).map_err(|e| BuildError::FtlParse(format!("{e:?}")))?;
 
-            if let Some(lang_name) = lang_name(&ast) {
-                if bundle.language_name.is_none() {
-                    bundle.language_name = Some(lang_name);
-                }
+            if let Some(lang_name) = lang_name(&ast)
+                && bundle.language_name.is_none()
+            {
+                bundle.language_name = Some(lang_name);
             }
             let name = path.file_stem().unwrap().to_str().unwrap().to_string();
 
@@ -120,8 +120,8 @@ fn lang_name(ast: &Resource<&str>) -> Option<String> {
                 }
                 let Some(value) = &m.value else { return None };
 
-                if let Some(TextElement { value }) = value.elements.iter().next() {
-                    return Some(value.to_string());
+                if let Some(TextElement { value }) = value.elements.first() {
+                    Some(value.to_string())
                 } else {
                     None
                 }

--- a/src/build/lang_bundle.rs
+++ b/src/build/lang_bundle.rs
@@ -47,14 +47,20 @@ impl LangBundle {
 
         let mut paths = folder
             .gather_all_files(|file| file.extension().map(|s| s == "ftl") == Some(true))
-            .map_err(|e| std::io::Error::other(e.to_string()))?;
+            .map_err(|e| BuildError::FtlRead {
+                path: folder.to_path_buf(),
+                source: std::io::Error::other(e.to_string()),
+            })?;
 
         paths.sort();
 
         let mut seen: HashMap<String, PathBuf> = HashMap::new();
 
         for path in paths {
-            let ftl = fs::read_to_string(&path)?;
+            let ftl = fs::read_to_string(&path).map_err(|e| BuildError::FtlRead {
+                path: path.clone(),
+                source: e,
+            })?;
             let ast =
                 parser::parse(ftl.as_str()).map_err(|e| BuildError::FtlParse(format!("{e:?}")))?;
 

--- a/src/build/lang_bundle.rs
+++ b/src/build/lang_bundle.rs
@@ -94,15 +94,15 @@ fn to_messages(
         .flatten()
         .map(|msg| {
             if deny_duplicate_keys {
-                let key = msg.id.message.clone();
-                if let Some(original) = seen.get(&key) {
+                let seen_key = msg.id.to_string();
+                if let Some(original) = seen.get(&seen_key) {
                     return Err(BuildError::DuplicateKey {
-                        key,
+                        key: msg.id.message.clone(),
                         original: original.clone(),
                         duplicate: path.to_path_buf(),
                     });
                 }
-                seen.insert(key, path.to_path_buf());
+                seen.insert(seen_key, path.to_path_buf());
             }
             Ok(msg)
         })

--- a/src/build/lang_bundle.rs
+++ b/src/build/lang_bundle.rs
@@ -94,7 +94,7 @@ fn to_messages(
         .flatten()
         .map(|msg| {
             if deny_duplicate_keys {
-                let key = msg.id.to_string();
+                let key = msg.id.message.clone();
                 if let Some(original) = seen.get(&key) {
                     return Err(BuildError::DuplicateKey {
                         key,

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -1,4 +1,5 @@
 mod builder;
+mod error;
 pub mod r#gen;
 mod lang_bundle;
 pub mod options;
@@ -7,6 +8,7 @@ mod utils;
 mod validations;
 
 pub use builder::Builder;
+pub use error::BuildError;
 pub use lang_bundle::LangBundle;
 pub use options::{BuildOptions, FtlOutputOptions, OutputMode};
 use std::process::ExitCode;
@@ -54,7 +56,7 @@ pub fn build_from_locales_folder(options: BuildOptions) -> ExitCode {
 }
 
 /// Same as [build_from_locales_folder], but returns result instead of an ExitCode.
-pub fn try_build_from_locales_folder(options: BuildOptions) -> Result<(), String> {
+pub fn try_build_from_locales_folder(options: BuildOptions) -> Result<(), BuildError> {
     let locales = &options.locales_folder;
     println!("cargo::rerun-if-changed={locales}");
 

--- a/src/build/options/build_options.rs
+++ b/src/build/options/build_options.rs
@@ -39,6 +39,12 @@ pub struct BuildOptions {
     ///
     /// Defaults to OutputMode::String with prefix "msg_".
     pub output_mode: OutputMode,
+
+    /// Whether to return an error if duplicate message keys are found
+    /// within the same language.
+    ///
+    /// Defaults to false.
+    pub deny_duplicate_keys: bool,
 }
 
 impl Default for BuildOptions {
@@ -51,6 +57,7 @@ impl Default for BuildOptions {
             default_language: "en".to_string(),
             format: true,
             output_mode: OutputMode::default(),
+            deny_duplicate_keys: false,
         }
     }
 }
@@ -88,6 +95,11 @@ impl BuildOptions {
 
     pub fn with_output_mode(mut self, mode: OutputMode) -> Self {
         self.output_mode = mode;
+        self
+    }
+
+    pub fn with_deny_duplicate_keys(mut self) -> Self {
+        self.deny_duplicate_keys = true;
         self
     }
 

--- a/src/build/options/build_options.rs
+++ b/src/build/options/build_options.rs
@@ -43,7 +43,7 @@ pub struct BuildOptions {
     /// Whether to return an error if duplicate message keys are found
     /// within the same language.
     ///
-    /// Defaults to false.
+    /// Defaults to true.
     pub deny_duplicate_keys: bool,
 }
 
@@ -57,7 +57,7 @@ impl Default for BuildOptions {
             default_language: "en".to_string(),
             format: true,
             output_mode: OutputMode::default(),
-            deny_duplicate_keys: false,
+            deny_duplicate_keys: true,
         }
     }
 }
@@ -98,8 +98,8 @@ impl BuildOptions {
         self
     }
 
-    pub fn with_deny_duplicate_keys(mut self) -> Self {
-        self.deny_duplicate_keys = true;
+    pub fn with_allow_duplicate_keys(mut self) -> Self {
+        self.deny_duplicate_keys = false;
         self
     }
 

--- a/src/build/options/ftl_output_options.rs
+++ b/src/build/options/ftl_output_options.rs
@@ -141,7 +141,7 @@ fn write(content: &[u8], file: &Path) -> Result<(), String> {
 
 fn create_dir(folder: &Path) -> Result<(), String> {
     if !folder.exists() {
-        fs::create_dir_all(&folder)
+        fs::create_dir_all(folder)
             .map_err(|e| format!("Could not create ftl folder '{folder:?}': {e:?}"))?;
     }
     Ok(())

--- a/src/build/validations.rs
+++ b/src/build/validations.rs
@@ -16,7 +16,7 @@ impl Analyzed {
         let common_ids = common_message_ids(langs);
         let missing_messages = missing_message_ids(&common_ids, langs);
         let (signature_mismatches, ids) = signature_mismatches(&common_ids, langs);
-        let common: HashSet<Id> = common_ids.difference(&ids).map(|id| id.clone()).collect();
+        let common: HashSet<Id> = common_ids.difference(&ids).cloned().collect();
         Self {
             common,
             missing_messages,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ pub mod prelude {
     pub use fluent_bundle::{FluentArgs, FluentValue, types::FluentNumber};
     pub use fluent_syntax::ast::{Pattern, PatternElement};
     #[cfg(feature = "langneg")]
-    pub use icu_locale_core::{langid, LanguageIdentifier};
+    pub use icu_locale_core::{LanguageIdentifier, langid};
 
     #[cfg(feature = "langneg")]
     pub fn negotiate_languages<'a, A>(accept_language: &str, available: &'a [A]) -> A
@@ -44,7 +44,9 @@ pub mod prelude {
                 } else {
                     (entry, 1000)
                 };
-                tag.parse::<LanguageIdentifier>().ok().map(|lid| (lid, quality))
+                tag.parse::<LanguageIdentifier>()
+                    .ok()
+                    .map(|lid| (lid, quality))
             })
             .collect();
         requested.sort_by(|a, b| b.1.cmp(&a.1));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ mod tests;
 
 #[cfg(any(doc, feature = "build"))]
 pub use build::{
-    BuildOptions, FtlOutputOptions, OutputMode, build_from_locales_folder,
+    BuildError, BuildOptions, FtlOutputOptions, OutputMode, build_from_locales_folder,
     try_build_from_locales_folder,
 };
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -179,6 +179,25 @@ fn test_locales_deep_folders() {
     assert!(generated.contains("L10n::En"));
 }
 
+#[test]
+fn test_duplicate_key_fails() {
+    let ftl = r#"
+hello-world = Hello World!
+hello-world = Goodbye World!
+"#;
+
+    let ftl_opts = FtlOutputOptions::SingleFile {
+        output_ftl_file: "src/tests/gen/test_duplicate_key.ftl".to_string(),
+        compressor: None,
+    };
+    let options = BuildOptions::default()
+        .with_output_file_path("src/tests/gen/test_duplicate_key_gen.rs")
+        .with_ftl_output(ftl_opts);
+
+    let result = Builder::load_one(options, "test", "en", ftl);
+    assert!(result.is_err(), "Expected an error for duplicate keys");
+}
+
 // #[test]
 // fn test_locales_ld() {
 //     let locales = build::from_locales_folder("../../../LeaveDates/frontend/app/locales").unwrap();

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -4,7 +4,7 @@ mod r#gen;
 
 use std::fs;
 
-use crate::{BuildOptions, FtlOutputOptions, OutputMode, build::Builder};
+use crate::{BuildError, BuildOptions, FtlOutputOptions, OutputMode, build::Builder};
 
 use fluent_bundle::{FluentBundle, FluentResource};
 use unic_langid::langid;
@@ -196,7 +196,10 @@ hello-world = Goodbye World!
         .with_deny_duplicate_keys();
 
     let result = Builder::load_one(options, "test", "en", ftl);
-    assert!(result.is_err(), "Expected an error for duplicate keys");
+    assert!(
+        matches!(result, Err(BuildError::DuplicateKey(_))),
+        "Expected a DuplicateKey error"
+    );
 }
 
 // #[test]

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -192,7 +192,8 @@ hello-world = Goodbye World!
     };
     let options = BuildOptions::default()
         .with_output_file_path("src/tests/gen/test_duplicate_key_gen.rs")
-        .with_ftl_output(ftl_opts);
+        .with_ftl_output(ftl_opts)
+        .with_deny_duplicate_keys();
 
     let result = Builder::load_one(options, "test", "en", ftl);
     assert!(result.is_err(), "Expected an error for duplicate keys");

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -197,7 +197,7 @@ hello-world = Goodbye World!
 
     let result = Builder::load_one(options, "test", "en", ftl);
     assert!(
-        matches!(result, Err(BuildError::DuplicateKey(_))),
+        matches!(result, Err(BuildError::DuplicateKey { .. })),
         "Expected a DuplicateKey error"
     );
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -213,6 +213,31 @@ fn test_duplicate_key_fails() {
     }
 }
 
+#[test]
+fn test_duplicate_key_single_file_fails() {
+    let ftl = "hello-world = Hello\nhello-world = World\n";
+    let ftl_opts = FtlOutputOptions::SingleFile {
+        output_ftl_file: "src/tests/gen/test_duplicate_key_single.ftl".to_string(),
+        compressor: None,
+    };
+    let options = BuildOptions::default()
+        .with_output_file_path("src/tests/gen/test_duplicate_key_single_gen.rs")
+        .with_ftl_output(ftl_opts)
+        .with_deny_duplicate_keys();
+
+    if let Err(BuildError::DuplicateKey {
+        key,
+        original,
+        duplicate,
+    }) = &Builder::load_one(options, "test", "en", ftl)
+    {
+        assert_eq!(key, "message 'hello-world'");
+        assert_eq!(original, duplicate);
+    } else {
+        panic!("Expected a DuplicateKey error");
+    }
+}
+
 // #[test]
 // fn test_locales_ld() {
 //     let locales = build::from_locales_folder("../../../LeaveDates/frontend/app/locales").unwrap();

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -191,12 +191,11 @@ fn test_duplicate_key_fails() {
         .with_ftl_output(ftl_opts)
         .with_default_language("en");
 
-    if let Err(BuildError::LocalesFolder { source, .. }) = &Builder::load(options)
-        && let BuildError::DuplicateKey {
-            key,
-            original,
-            duplicate,
-        } = source.as_ref()
+    if let Err(BuildError::DuplicateKey {
+        key,
+        original,
+        duplicate,
+    }) = &Builder::load(options)
     {
         assert_eq!(key, "hello-world");
         assert!(

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -189,8 +189,7 @@ fn test_duplicate_key_fails() {
         .with_locales_folder("src/tests/test_duplicate_key")
         .with_output_file_path("src/tests/gen/test_duplicate_key_gen.rs")
         .with_ftl_output(ftl_opts)
-        .with_default_language("en")
-        .with_deny_duplicate_keys();
+        .with_default_language("en");
 
     if let Err(BuildError::LocalesFolder { source, .. }) = &Builder::load(options)
         && let BuildError::DuplicateKey {
@@ -222,8 +221,7 @@ fn test_duplicate_key_single_file_fails() {
     };
     let options = BuildOptions::default()
         .with_output_file_path("src/tests/gen/test_duplicate_key_single_gen.rs")
-        .with_ftl_output(ftl_opts)
-        .with_deny_duplicate_keys();
+        .with_ftl_output(ftl_opts);
 
     if let Err(BuildError::DuplicateKey {
         key,

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -199,7 +199,7 @@ fn test_duplicate_key_fails() {
             duplicate,
         } = source.as_ref()
     {
-        assert_eq!(key, "message 'hello-world'");
+        assert_eq!(key, "hello-world");
         assert!(
             original.ends_with("a.ftl"),
             "expected a.ftl, got {original:?}"
@@ -231,7 +231,7 @@ fn test_duplicate_key_single_file_fails() {
         duplicate,
     }) = &Builder::load_one(options, "test", "en", ftl)
     {
-        assert_eq!(key, "message 'hello-world'");
+        assert_eq!(key, "hello-world");
         assert_eq!(original, duplicate);
     } else {
         panic!("Expected a DuplicateKey error");

--- a/src/tests/test_duplicate_key/en/a.ftl
+++ b/src/tests/test_duplicate_key/en/a.ftl
@@ -1,0 +1,1 @@
+hello-world = Hello World!

--- a/src/tests/test_duplicate_key/en/b.ftl
+++ b/src/tests/test_duplicate_key/en/b.ftl
@@ -1,0 +1,1 @@
+hello-world = Goodbye World!


### PR DESCRIPTION
## Summary

### BuildError enum

The build pipeline was using `Result<_, String>` for all errors, making it difficult to programmatically distinguish between error types. This replaces them with a `BuildError` enum that implements `std::error::Error` and `Display`, with variants for each error case: `FtlParse`, `Io`, `DuplicateKey`, `LocalesFolder`, `WriteOutput`, `Rustfmt`, and `Generation`.

### Duplicate key validation

The fluent parser silently accepts duplicate message keys. This can hide mistakes in translation files. A new `BuildOptions::with_deny_duplicate_keys()` option makes this an explicit build error. It is opt-in to avoid breaking existing usage.