### PR TITLE
Code-review follow-up: bidi isolation, tests, README, cleanups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- `BuildOptions::without_bidi_isolation()` and the `BuildOptions::use_isolating`
+  field to control whether generated accessors wrap interpolated variables in
+  Unicode bidi isolation marks (FSI/PDI). Defaults to enabled.
+- `L10nBundle::new_without_isolation()` and
+  `L10nLanguageVec::load_without_isolation()` constructors.
+
+### Changed
+- **Breaking:** `BuildOptions` has a new `use_isolating` field (default
+  `true`). Direct struct construction must include this field;
+  `BuildOptions::default()` users are unaffected.
+
+### Fixed
+- An empty locales folder now returns the new `BuildError::NoLocaleFolders`
+  variant instead of panicking.
+
 ## 0.5.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ part of the crate's public interface.
 ```toml
 # in Cargo.toml
 [dependencies]
-fluent-typed = 0.1
+fluent-typed = "0.5"
 
 [build-dependencies]
-fluent-typed = { version = "0.1", features = ["build"] }
+fluent-typed = { version = "0.5", features = ["build"] }
 ```
 
 ```rust
@@ -65,13 +65,13 @@ fn main() -> std::process::ExitCode {
 mod l10n;
 use l10n::L10n;
 
-// Load english translations in an L10nLanguage struct.
-// It provides safe function for accessing all messages.
+// Load English translations into an L10nLanguage struct.
+// It provides safe functions for accessing all messages.
 let strs: L10nLanguage = L10n::EnGb.load();
 
 // With the feature "langneg" enabled you can do automatic language
 // negotiation, which falls back on the default language as
-// configured in the BuildOptions in the build.rs when generating.
+// configured in the BuildOptions in build.rs when generating.
 let found_lang: L10nLanguage = L10n::langneg("en");
 
 // In Dioxus/Leptos/Silkenweb etc the L10nLanguage struct is typically
@@ -81,18 +81,21 @@ let found_lang: L10nLanguage = L10n::langneg("en");
 // A message without arguments.
 assert_eq!("Welcome!", strs.msg_greeting());
 // A message with a string argument (AsRef<str>).
-assert_eq!("Hello world", strs.msg_hello("world"));
+let hello: String = strs.msg_hello("world");
 // A message with a number argument (Into<FluentNumber>).
-assert_eq!("You have 2 unread messages", strs.msg_unread_messages(2));
+let unread: String = strs.msg_unread_messages(2);
+// Note: interpolated values are wrapped in Unicode bidi isolation
+// marks by default, so `hello` is "Hello \u{2068}world\u{2069}".
+// See "Bidi isolation" below.
 
-// the list of the translated, human-readable language names.
+// The list of translated, human-readable language names.
 let language_names: Vec<&str>
-  = L10n.iter().map(|lang| lang.language_name()).collect();
+  = L10n::iter().map(|lang| lang.language_name()).collect();
 
-// typically server-side, you'll load all the languages
+// Server-side, you typically load all the languages once.
 let languages = L10n::load_all();
-// then you can use it like
-assert_eq!("Welcome!", languages.get(L10n::en).msg_greeting());
+// `get` returns the lower-level `L10nBundle`; access messages by id:
+let greeting = languages.get(L10n::En).msg("greeting", None).unwrap();
 ```
 
 ## Output modes
@@ -130,10 +133,11 @@ project uses the following rules to infer the type of the translation variables:
   - If a variable's comment contains `(String)`, as in `# $name (String) - The name.`
 - Number:
   - If a variable's comment contains `(Number)`, as in `# $count (Number) - How many.`
-  - If a [NUMBER](https://projectfluent.org/fluent/guide/functions.html#number-1) function is used, asin `dpi-ratio = Your DPI ratio is { NUMBER($ratio) }`
+  - If a [NUMBER](https://projectfluent.org/fluent/guide/functions.html#number-1) function is used, as in `dpi-ratio = Your DPI ratio is { NUMBER($ratio) }`
   - If a [selector](https://projectfluent.org/fluent/guide/selectors.html) only contains numbers
-    and CLDR plural catagories: `zero`, `one`, `two`, `few`, `many`, and `other`. Example:
-    `text
+    and CLDR plural categories (`zero`, `one`, `two`, `few`, `many`, `other`). For example:
+
+```text
 your-rank = { NUMBER($pos, type: "ordinal") ->
    [1] You finished first!
    [one] You finished {$pos}st
@@ -141,5 +145,25 @@ your-rank = { NUMBER($pos, type: "ordinal") ->
    [few] You finished {$pos}rd
   *[other] You finished {$pos}th
 }
-`
-    gg
+```
+
+## Bidi isolation
+
+By default, the generated accessors wrap every interpolated variable in Unicode
+bidi isolation marks (FSI `U+2068` … PDI `U+2069`). This is the safe default for
+text rendered in a bidi-aware context such as a web UI: it keeps an interpolated
+value's text direction from corrupting the surrounding message, which matters
+whenever a right-to-left locale is used or user-provided text is interpolated.
+
+```rust
+// strs.msg_hello("world") == "Hello \u{2068}world\u{2069}"
+```
+
+If the generated strings are never rendered in a bidi-aware context — and you do
+not use right-to-left locales or interpolate user-provided text — you can turn
+the marks off:
+
+```rust
+// in build.rs
+let options = BuildOptions::default().without_bidi_isolation();
+```

--- a/README.md
+++ b/README.md
@@ -29,6 +29,38 @@ part of the crate's public interface.
 
 ## Usage
 
+Translations live in a `locales/` folder, with one subfolder per language
+(`locales/en/`, `locales/fr/`, …) holding `.ftl`
+([Fluent](https://projectfluent.org)) files:
+
+```ftl
+# locales/en/main.ftl
+language-name = English
+greeting = Welcome!
+
+# $name (String) - the user's name
+hello = Hello { $name }
+
+unread-messages = { $count ->
+    [one] You have one message
+   *[other] You have { $count } messages
+}
+
+login = Log in
+    .placeholder = Enter your email
+```
+
+fluent-typed turns each message into a typed accessor on `L10nLanguage`,
+inferring argument types from comments, `NUMBER()` calls and plural selectors:
+
+```rust
+strs.msg_greeting();            // plain message -> String
+strs.msg_hello("Sam");          // string arg (typed via the comment)
+strs.msg_unread_messages(3);    // number arg (typed via the plural selector)
+strs.msg_login_placeholder();   // a message attribute
+L10n::En.language_name();       // language name, for a language menu
+```
+
 ```toml
 # in Cargo.toml
 [dependencies]

--- a/src/build/builder.rs
+++ b/src/build/builder.rs
@@ -109,5 +109,10 @@ fn from_locales_folder(
             locales.push(LangBundle::from_folder(&path, lang, deny_duplicate_keys)?);
         }
     }
+    if locales.is_empty() {
+        return Err(BuildError::NoLocaleFolders {
+            folder: folder.to_string(),
+        });
+    }
     Ok(locales)
 }

--- a/src/build/error.rs
+++ b/src/build/error.rs
@@ -16,6 +16,9 @@ pub enum BuildError {
         folder: String,
         source: io::Error,
     },
+    NoLocaleFolders {
+        folder: String,
+    },
     WriteOutput {
         path: String,
         source: io::Error,
@@ -53,6 +56,13 @@ impl fmt::Display for BuildError {
             }
             Self::LocalesFolder { folder, .. } => {
                 write!(f, "Could not read locales folder '{folder}'")
+            }
+            Self::NoLocaleFolders { folder } => {
+                write!(
+                    f,
+                    "No locale subfolders found in '{folder}'. Expected \
+                     '<lang-id>/<resource>.ftl' files, e.g. 'en/main.ftl'."
+                )
             }
             Self::WriteOutput { path, .. } => {
                 write!(f, "Could not write file '{path}'")

--- a/src/build/gen/generated_ftl.rs
+++ b/src/build/gen/generated_ftl.rs
@@ -32,13 +32,13 @@ impl GeneratedFtl {
         })
     }
 
-    pub fn accessor_replacement(&self) -> String {
+    pub fn accessor_replacement(&self, use_isolating: bool) -> String {
         match self {
             Self::SingleFile {
                 positions,
                 compressed,
                 ..
-            } => self.single_file_load_fn(positions, *compressed),
+            } => self.single_file_load_fn(positions, *compressed, use_isolating),
             Self::MultiFile => "".to_string(),
         }
     }
@@ -47,6 +47,7 @@ impl GeneratedFtl {
         &self,
         positions: &[(String, Range<usize>)],
         compressed: bool,
+        use_isolating: bool,
     ) -> String {
         let mut out = String::new();
 
@@ -107,6 +108,13 @@ impl GeneratedFtl {
         };
 
         out.push_str(load_all_fn);
+
+        if !use_isolating {
+            out = out.replace(
+                "L10nLanguageVec::load(",
+                "L10nLanguageVec::load_without_isolation(",
+            );
+        }
         out
     }
 }

--- a/src/build/gen/mod.rs
+++ b/src/build/gen/mod.rs
@@ -1,6 +1,12 @@
 mod ext;
 mod generated_ftl;
 mod message;
+// `template.rs` is used in two ways: it is compiled as a normal module so the
+// compiler guarantees the skeleton stays valid Rust, and it is also read as a
+// string by `generate()` (via `include_str!`) and expanded by replacing the
+// `<<placeholder ...>>` markers. The `#[allow(...)]` below silences lints that
+// only apply to the never-executed compiled copy. The sibling `ftl.bin` is an
+// empty stub that exists only so the template's `include_bytes!` compiles.
 #[allow(dead_code, unused_mut, unused_imports, clippy::derivable_impls)]
 mod template;
 
@@ -189,8 +195,16 @@ static ALL_LANGS: [L10n; {}] = [
     // ///////////////////////////
     replacements.push((
         "<<placeholder load functions>>",
-        generated_ftl.accessor_replacement(),
+        generated_ftl.accessor_replacement(options.use_isolating),
     ));
+
+    // ///////////////////////////
+    let l10n_bundle_new = if options.use_isolating {
+        "        Ok(Self(L10nBundle::new(lang, bytes)?))".to_string()
+    } else {
+        "        Ok(Self(L10nBundle::new_without_isolation(lang, bytes)?))".to_string()
+    };
+    replacements.push(("<<placeholder l10n bundle new>>", l10n_bundle_new));
 
     // ///////////////////////////
     let impls = collect(messages.iter(), |msg| {

--- a/src/build/lang_bundle.rs
+++ b/src/build/lang_bundle.rs
@@ -29,7 +29,7 @@ impl LangBundle {
         Ok(LangBundle {
             language_name: lang_name(&ast),
             language_id: lang.to_string(),
-            messages: to_messages(name, &ast, deny_duplicate_keys, &mut seen, &path)?,
+            messages: to_messages(&ast, deny_duplicate_keys, &mut seen, &path)?,
             ftl: ftl.to_string(),
         })
     }
@@ -77,7 +77,7 @@ impl LangBundle {
             bundle.ftl.push_str(&ftl);
             bundle.ftl.push('\n');
 
-            let messages = to_messages(&name, &ast, deny_duplicate_keys, &mut seen, &path)?;
+            let messages = to_messages(&ast, deny_duplicate_keys, &mut seen, &path)?;
             bundle.messages.extend(messages);
         }
         Ok(bundle)
@@ -85,7 +85,6 @@ impl LangBundle {
 }
 
 fn to_messages(
-    name: &str,
     ast: &Resource<&str>,
     deny_duplicate_keys: bool,
     seen: &mut HashMap<String, PathBuf>,
@@ -94,7 +93,7 @@ fn to_messages(
     ast.body
         .iter()
         .filter_map(|entry| match entry {
-            fluent_syntax::ast::Entry::Message(m) => Some(Message::parse(name, m)),
+            fluent_syntax::ast::Entry::Message(m) => Some(Message::parse(m)),
             _ => None,
         })
         .flatten()

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -7,13 +7,16 @@ pub mod typed;
 mod utils;
 mod validations;
 
-pub use builder::Builder;
 pub use error::BuildError;
-pub use lang_bundle::LangBundle;
 pub use options::{BuildOptions, FtlOutputOptions, OutputMode};
 use std::process::ExitCode;
-pub use typed::Message;
-pub use validations::Analyzed;
+
+// Crate-internal: the `build` module itself is private, so these are not part
+// of the public API. They are re-exported here only for use within the crate.
+pub(crate) use builder::Builder;
+pub(crate) use lang_bundle::LangBundle;
+pub(crate) use typed::Message;
+pub(crate) use validations::Analyzed;
 
 /// Generate rust code and ftl files from locales folder, which contains `<lang-id>/<resource-name>.ftl` files.
 ///

--- a/src/build/options/build_options.rs
+++ b/src/build/options/build_options.rs
@@ -45,6 +45,16 @@ pub struct BuildOptions {
     ///
     /// Defaults to true.
     pub deny_duplicate_keys: bool,
+
+    /// Whether the generated code wraps interpolated variables in Unicode
+    /// bidi isolation marks (FSI `U+2068` / PDI `U+2069`).
+    ///
+    /// This is the safe default for text rendered in a bidi-aware context
+    /// such as a web UI, and is required for correct rendering when a
+    /// right-to-left locale is used or user-provided text is interpolated.
+    ///
+    /// Defaults to true.
+    pub use_isolating: bool,
 }
 
 impl Default for BuildOptions {
@@ -58,6 +68,7 @@ impl Default for BuildOptions {
             format: true,
             output_mode: OutputMode::default(),
             deny_duplicate_keys: true,
+            use_isolating: true,
         }
     }
 }
@@ -100,6 +111,17 @@ impl BuildOptions {
 
     pub fn with_allow_duplicate_keys(mut self) -> Self {
         self.deny_duplicate_keys = false;
+        self
+    }
+
+    /// Disable Unicode bidi isolation marks around interpolated variables
+    /// in the generated code. See [`BuildOptions::use_isolating`].
+    ///
+    /// Only do this if the generated strings are never rendered in a
+    /// bidi-aware context, or you never use right-to-left locales or
+    /// interpolate user-provided text.
+    pub fn without_bidi_isolation(mut self) -> Self {
+        self.use_isolating = false;
         self
     }
 

--- a/src/build/typed/mod.rs
+++ b/src/build/typed/mod.rs
@@ -8,9 +8,6 @@ use crate::build::r#gen::StrExt;
 #[derive(Debug, PartialEq)]
 pub struct Message {
     pub id: Id,
-    /// The name of the resource file.
-    /// This is used for error messages.
-    pub resource: String,
     pub comment: Vec<String>,
     pub variables: Vec<Variable>,
 }

--- a/src/build/typed/parse_ast.rs
+++ b/src/build/typed/parse_ast.rs
@@ -3,7 +3,7 @@ use fluent_syntax::ast;
 use type_in_comment::TypeInComment;
 
 impl Message {
-    pub fn parse(resource: &str, message: &ast::Message<&str>) -> Vec<Self> {
+    pub fn parse(message: &ast::Message<&str>) -> Vec<Self> {
         let mut found = Vec::new();
         let comment = message
             .comment
@@ -19,7 +19,6 @@ impl Message {
                 attribute: None,
             };
             found.push(Self {
-                resource: resource.to_owned(),
                 id,
                 comment,
                 variables,
@@ -32,7 +31,6 @@ impl Message {
                 attribute: Some(attribute.id.to_owned()),
             };
             found.push(Self {
-                resource: resource.to_owned(),
                 id,
                 comment: vec![],
                 variables,

--- a/src/build/typed/type_in_comment.rs
+++ b/src/build/typed/type_in_comment.rs
@@ -52,7 +52,7 @@ fn parse_line(line: &str) -> Found<'_> {
     let id = &id[1..];
 
     let rest = rest.trim();
-    if rest.trim().starts_with("(Number)") {
+    if rest.starts_with("(Number)") {
         Found::Number(id)
     } else if rest.starts_with("(String)") {
         Found::String(id)

--- a/src/build/validations.rs
+++ b/src/build/validations.rs
@@ -77,7 +77,9 @@ fn common_message_ids(langs: &[LangBundle]) -> HashSet<Id> {
         );
     }
     let mut iter = lang_signatures.iter();
-    let mut common = iter.next().unwrap().clone();
+    // Safe: `from_locales_folder` rejects an empty locales folder, and
+    // `Builder::load_one` always produces exactly one bundle.
+    let mut common = iter.next().expect("at least one language bundle").clone();
 
     for other in iter {
         common = common.intersection(other).cloned().collect();

--- a/src/l10n_bundle.rs
+++ b/src/l10n_bundle.rs
@@ -11,11 +11,30 @@ pub struct L10nBundle {
 }
 
 impl L10nBundle {
+    /// Load the messages for `lang` from the bytes of a `.ftl` file.
+    ///
+    /// Interpolated variables are wrapped in Unicode bidi isolation marks
+    /// (FSI `U+2068` / PDI `U+2069`), which is the safe default for text
+    /// rendered in a bidi-aware context such as a web UI. Use
+    /// [`Self::new_without_isolation`] to disable this.
     pub fn new(lang: impl AsRef<str>, bytes: &[u8]) -> Result<Self, String> {
+        Self::build(lang, bytes, true)
+    }
+
+    /// Like [`Self::new`], but without Unicode bidi isolation marks around
+    /// interpolated variables. Only use this if the strings are never
+    /// rendered in a bidi-aware context, or you never use right-to-left
+    /// locales or interpolate user-provided text.
+    pub fn new_without_isolation(lang: impl AsRef<str>, bytes: &[u8]) -> Result<Self, String> {
+        Self::build(lang, bytes, false)
+    }
+
+    fn build(lang: impl AsRef<str>, bytes: &[u8], use_isolating: bool) -> Result<Self, String> {
         let ftl = String::from_utf8(bytes.to_vec())
             .map_err(|e| format!("Could not read ftl string due to: {e}"))?;
         let lang_id: LanguageIdentifier = lang.as_ref().parse().map_err(|e| format!("{e:?}"))?;
         let mut bundle = FluentBundle::new(vec![lang_id]);
+        bundle.set_use_isolating(use_isolating);
         let resource = FluentResource::try_new(ftl).map_err(|e| format!("{e:?}"))?;
         bundle
             .add_resource(resource)

--- a/src/l10n_language_vec.rs
+++ b/src/l10n_language_vec.rs
@@ -7,14 +7,41 @@ pub struct L10nLanguageVec {
 }
 
 impl L10nLanguageVec {
+    /// Load all languages, with Unicode bidi isolation marks around
+    /// interpolated variables. See [`L10nBundle::new`].
     pub fn load<S, I>(bytes: &[u8], iter: I) -> Result<Self, String>
+    where
+        S: AsRef<str>,
+        I: Iterator<Item = (S, Range<usize>)>,
+    {
+        Self::build(bytes, iter, true)
+    }
+
+    /// Load all languages, without Unicode bidi isolation marks. See
+    /// [`L10nBundle::new_without_isolation`].
+    pub fn load_without_isolation<S, I>(bytes: &[u8], iter: I) -> Result<Self, String>
+    where
+        S: AsRef<str>,
+        I: Iterator<Item = (S, Range<usize>)>,
+    {
+        Self::build(bytes, iter, false)
+    }
+
+    fn build<S, I>(bytes: &[u8], iter: I, use_isolating: bool) -> Result<Self, String>
     where
         S: AsRef<str>,
         I: Iterator<Item = (S, Range<usize>)>,
     {
         Ok(Self {
             langs: iter
-                .map(|(lang, range)| L10nBundle::new(lang, &bytes[range]))
+                .map(|(lang, range)| {
+                    let data = &bytes[range];
+                    if use_isolating {
+                        L10nBundle::new(lang, data)
+                    } else {
+                        L10nBundle::new_without_isolation(lang, data)
+                    }
+                })
                 .collect::<Result<Vec<_>, String>>()?,
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ pub mod prelude {
                     .map(|lid| (lid, quality))
             })
             .collect();
-        requested.sort_by(|a, b| b.1.cmp(&a.1));
+        requested.sort_by_key(|entry| std::cmp::Reverse(entry.1));
 
         // Find the first available language whose language subtag matches a requested one
         for (req, _) in &requested {

--- a/src/tests/ast/attrib_only.rs
+++ b/src/tests/ast/attrib_only.rs
@@ -75,7 +75,6 @@ fn typed() {
         message,
         Message {
             comment: vec![],
-            resource: "test".to_string(),
             id: Id::new_attr("hello", "tooltip"),
             variables: vec![Variable {
                 id: "userName".to_string(),

--- a/src/tests/ast/mod.rs
+++ b/src/tests/ast/mod.rs
@@ -28,26 +28,14 @@ fn load_bundle() {
 }
 
 trait AstResourceExt {
-    fn first_message_in_resource<'a>(&'a self, resource: &'a str) -> Message;
     fn first_message(&self) -> Message;
     fn two_messages(&self) -> [Message; 2];
 }
 
 impl AstResourceExt for ast::Resource<&str> {
-    fn first_message_in_resource<'a>(&'a self, resource: &'a str) -> Message {
-        match &self.body[0] {
-            ast::Entry::Message(message) => Message::parse(resource, message)
-                .into_iter()
-                .next()
-                .unwrap(),
-            _ => panic!("Expected a message."),
-        }
-    }
     fn first_message(&self) -> Message {
         match &self.body[0] {
-            ast::Entry::Message(message) => {
-                Message::parse("test", message).into_iter().next().unwrap()
-            }
+            ast::Entry::Message(message) => Message::parse(message).into_iter().next().unwrap(),
             _ => panic!("Expected a message."),
         }
     }
@@ -55,7 +43,7 @@ impl AstResourceExt for ast::Resource<&str> {
     fn two_messages(&self) -> [Message; 2] {
         match &self.body[0] {
             ast::Entry::Message(message) => {
-                let msgs = Message::parse("test", message);
+                let msgs = Message::parse(message);
                 assert_eq!(msgs.len(), 2);
                 msgs.try_into().unwrap()
             }

--- a/src/tests/ast/msg_number.rs
+++ b/src/tests/ast/msg_number.rs
@@ -71,7 +71,6 @@ fn typed() {
     assert_eq!(
         message,
         Message {
-            resource: "test".to_string(),
             id: Id::new_msg("time-elapsed"),
             comment: vec!["$duration (Number) - The duration in seconds.".to_string()],
             variables: vec![Variable {

--- a/src/tests/ast/msg_select.rs
+++ b/src/tests/ast/msg_select.rs
@@ -82,7 +82,6 @@ fn typed() {
     assert_eq!(
         message,
         Message {
-            resource: "test".to_string(),
             id: Id::new_msg("key"),
             comment: vec![],
             variables: vec![Variable {

--- a/src/tests/ast/msg_select_num.rs
+++ b/src/tests/ast/msg_select_num.rs
@@ -95,7 +95,6 @@ fn typed() {
     assert_eq!(
         message,
         Message {
-            resource: "test".to_string(),
             id: Id::new_msg("liked-count"),
             comment: vec![],
             variables: vec![Variable {

--- a/src/tests/ast/msg_string.rs
+++ b/src/tests/ast/msg_string.rs
@@ -66,7 +66,6 @@ fn typed() {
     assert_eq!(
         message,
         Message {
-            resource: "test".to_string(),
             id: Id::new_msg("greeting"),
             comment: vec!["$name (String) - The name.".to_string()],
             variables: vec![Variable {

--- a/src/tests/ast/msg_text.rs
+++ b/src/tests/ast/msg_text.rs
@@ -57,7 +57,6 @@ fn typed() {
     assert_eq!(
         message,
         Message {
-            resource: "test".to_string(),
             id: Id::new_msg("hello-world"),
             comment: vec![],
             variables: vec![],

--- a/src/tests/ast/msg_with_attrib.rs
+++ b/src/tests/ast/msg_with_attrib.rs
@@ -82,7 +82,6 @@ fn typed() {
     assert_eq!(
         message,
         Message {
-            resource: "test".to_string(),
             comment: vec!["This is a message comment".to_string()],
             id: Id::new_msg("hello"),
             variables: vec![],
@@ -92,7 +91,6 @@ fn typed() {
     assert_eq!(
         attr,
         Message {
-            resource: "test".to_string(),
             comment: vec![],
             id: Id::new_attr("hello", "tooltip"),
             variables: vec![Variable {

--- a/src/tests/ast/msg_with_var.rs
+++ b/src/tests/ast/msg_with_var.rs
@@ -62,7 +62,6 @@ fn typed() {
     assert_eq!(
         message,
         Message {
-            resource: "test".to_string(),
             id: Id::new_msg("hello"),
             comment: vec![],
             variables: vec![Variable {

--- a/src/tests/ast/res_msg_text.rs
+++ b/src/tests/ast/res_msg_text.rs
@@ -34,13 +34,12 @@ fn ast() {
 #[test]
 fn typed() {
     let resource = parser::parse(FTL).expect("Failed to parse an FTL resource.");
-    let message = resource.first_message_in_resource("cookie-disclaimer");
+    let message = resource.first_message();
 
     println!("{:#?}", message);
     assert_eq!(
         message,
         Message {
-            resource: "cookie-disclaimer".to_string(),
             id: Id::new_msg("hello-world"),
             comment: vec![],
             variables: vec![],

--- a/src/tests/gen/mod.rs
+++ b/src/tests/gen/mod.rs
@@ -1,4 +1,6 @@
-#![allow(unused)]
+// These are generated fixtures; the manual `impl Default` is intentional
+// (the default language is chosen at generation time).
+#![allow(unused, clippy::derivable_impls)]
 mod attrib_only_gen;
 mod complex_gen;
 mod msg_number_gen;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,6 +1,7 @@
 mod ast;
 mod complex;
 mod r#gen;
+mod runtime;
 
 use std::fs;
 
@@ -36,6 +37,9 @@ fn assert_gen(module: &str, resource_name: &str, ftl: &str) {
 
     let builder = Builder::load_one(options, resource_name, "en", ftl).unwrap();
     builder.generate().unwrap();
+
+    let generated = fs::read_to_string(&file).unwrap();
+    insta::assert_snapshot!(mod_name, generated);
 }
 
 #[track_caller]
@@ -59,12 +63,15 @@ fn assert_gen_with_output_mode(
 
     let builder = Builder::load_one(options, resource_name, "en", ftl).unwrap();
     builder.generate().unwrap();
+
+    let generated = fs::read_to_string(&file).unwrap();
+    insta::assert_snapshot!(format!("{mod_name}_{suffix}"), generated);
 }
 
 #[test]
 fn test_locales_folder() {
     let ftl_opts = FtlOutputOptions::SingleFile {
-        output_ftl_file: format!("src/tests/gen/test_locales.ftl"),
+        output_ftl_file: "src/tests/gen/test_locales.ftl".to_string(),
         compressor: None,
     };
     let options = BuildOptions::default()
@@ -73,12 +80,15 @@ fn test_locales_folder() {
         .with_output_file_path("src/tests/gen/test_locales_gen.rs")
         .with_default_language("en-gb");
     Builder::load(options).unwrap().generate().unwrap();
+
+    let generated = fs::read_to_string("src/tests/gen/test_locales_gen.rs").unwrap();
+    insta::assert_snapshot!("test_locales", generated);
 }
 
 #[test]
 fn test_locales_multi_resources() {
     let ftl_opts = FtlOutputOptions::SingleFile {
-        output_ftl_file: format!("src/tests/gen/test_locales_multi_resources.ftl"),
+        output_ftl_file: "src/tests/gen/test_locales_multi_resources.ftl".to_string(),
         compressor: None,
     };
     let options = BuildOptions::default()
@@ -88,12 +98,16 @@ fn test_locales_multi_resources() {
         .with_default_language("en-gb");
 
     Builder::load(options).unwrap().generate().unwrap();
+
+    let generated =
+        fs::read_to_string("src/tests/gen/test_locales_multi_resources_gen.rs").unwrap();
+    insta::assert_snapshot!("test_locales_multi_resources", generated);
 }
 
 #[test]
 fn test_locales_missing_msg() {
     let ftl_opts = FtlOutputOptions::SingleFile {
-        output_ftl_file: format!("src/tests/gen/test_locales_missing_msg.ftl"),
+        output_ftl_file: "src/tests/gen/test_locales_missing_msg.ftl".to_string(),
         compressor: None,
     };
     let options = BuildOptions::default()
@@ -102,6 +116,9 @@ fn test_locales_missing_msg() {
         .with_output_file_path("src/tests/gen/test_locales_missing_msg_gen.rs")
         .with_default_language("en-gb");
     Builder::load(options).unwrap().generate().unwrap();
+
+    let generated = fs::read_to_string("src/tests/gen/test_locales_missing_msg_gen.rs").unwrap();
+    insta::assert_snapshot!("test_locales_missing_msg", generated);
 }
 
 #[test]
@@ -167,6 +184,7 @@ fn test_locales_deep_folders() {
 
     // Verify the generated file contains messages from all depths
     let generated = fs::read_to_string("src/tests/gen/test_locales_deep_folders_gen.rs").unwrap();
+    insta::assert_snapshot!("test_locales_deep_folders", &generated);
 
     // Check that all expected message functions were generated
     assert!(generated.contains("fn msg_root_message("));
@@ -233,6 +251,49 @@ fn test_duplicate_key_single_file_fails() {
     } else {
         panic!("Expected a DuplicateKey error");
     }
+}
+
+#[test]
+fn empty_locales_folder_is_an_error() {
+    let dir = "target/test-empty-locales";
+    fs::create_dir_all(dir).unwrap();
+    let options = BuildOptions::default().with_locales_folder(dir);
+    assert!(
+        matches!(
+            Builder::load(options),
+            Err(BuildError::NoLocaleFolders { .. })
+        ),
+        "an empty locales folder should produce a NoLocaleFolders error, not a panic"
+    );
+}
+
+#[test]
+fn without_bidi_isolation_generates_non_isolating_calls() {
+    let dir = "target/test-gen-no-isolation";
+    fs::create_dir_all(dir).unwrap();
+    let rs = format!("{dir}/l10n.rs");
+    let options = BuildOptions::default()
+        .with_output_file_path(&rs)
+        .with_ftl_output(FtlOutputOptions::SingleFile {
+            output_ftl_file: format!("{dir}/translations.ftl"),
+            compressor: None,
+        })
+        .without_format()
+        .without_bidi_isolation();
+    Builder::load_one(options, "test", "en", "hello = Hi { $name }!\n")
+        .unwrap()
+        .generate()
+        .unwrap();
+
+    let generated = fs::read_to_string(&rs).unwrap();
+    assert!(
+        generated.contains("L10nBundle::new_without_isolation(lang, bytes)"),
+        "expected the non-isolating bundle constructor"
+    );
+    assert!(
+        generated.contains("L10nLanguageVec::load_without_isolation("),
+        "expected the non-isolating vec loader"
+    );
 }
 
 // #[test]

--- a/src/tests/runtime.rs
+++ b/src/tests/runtime.rs
@@ -1,0 +1,72 @@
+//! Behavioral tests for the runtime types (`L10nBundle`, `L10nLanguageVec`).
+//!
+//! These exercise the actual message-formatting path end to end, including
+//! the bidi-isolation behavior that the generated accessors depend on.
+
+use crate::prelude::{FluentArgs, L10nBundle, L10nLanguageVec};
+
+const FTL: &str = r#"
+greeting = Hello world
+hello = Hi { $name }!
+tip =
+    .label = Tip for { $name }
+"#;
+
+#[test]
+fn msg_without_variables() {
+    let bundle = L10nBundle::new("en", FTL.as_bytes()).unwrap();
+    assert_eq!(bundle.msg("greeting", None).unwrap(), "Hello world");
+}
+
+#[test]
+fn msg_with_variable_is_bidi_isolated_by_default() {
+    let bundle = L10nBundle::new("en", FTL.as_bytes()).unwrap();
+    let mut args = FluentArgs::new();
+    args.set("name", "world");
+    // By default, interpolated variables are wrapped in Unicode bidi
+    // isolation marks: FSI (U+2068) ... PDI (U+2069).
+    assert_eq!(
+        bundle.msg("hello", Some(args)).unwrap(),
+        "Hi \u{2068}world\u{2069}!"
+    );
+}
+
+#[test]
+fn msg_with_variable_without_isolation() {
+    let bundle = L10nBundle::new_without_isolation("en", FTL.as_bytes()).unwrap();
+    let mut args = FluentArgs::new();
+    args.set("name", "world");
+    assert_eq!(bundle.msg("hello", Some(args)).unwrap(), "Hi world!");
+}
+
+#[test]
+fn attribute_message() {
+    let bundle = L10nBundle::new_without_isolation("en", FTL.as_bytes()).unwrap();
+    let mut args = FluentArgs::new();
+    args.set("name", "Sam");
+    assert_eq!(
+        bundle.attr("tip", "label", Some(args)).unwrap(),
+        "Tip for Sam"
+    );
+}
+
+#[test]
+fn unknown_message_is_an_error() {
+    let bundle = L10nBundle::new("en", FTL.as_bytes()).unwrap();
+    assert!(bundle.msg("does-not-exist", None).is_err());
+}
+
+#[test]
+fn language_vec_loads_each_range() {
+    let en = "greeting = Hello\n";
+    let de = "greeting = Hallo\n";
+    let mut data = Vec::new();
+    data.extend_from_slice(en.as_bytes());
+    data.extend_from_slice(de.as_bytes());
+
+    let ranges = [("en", 0..en.len()), ("de", en.len()..data.len())];
+    let vec = L10nLanguageVec::load(&data, ranges.into_iter()).unwrap();
+
+    assert_eq!(vec.get("en").msg("greeting", None).unwrap(), "Hello");
+    assert_eq!(vec.get("de").msg("greeting", None).unwrap(), "Hallo");
+}

--- a/src/tests/snapshots/fluent_typed__tests__attrib_only.snap
+++ b/src/tests/snapshots/fluent_typed__tests__attrib_only.snap
@@ -1,0 +1,129 @@
+---
+source: src/tests/mod.rs
+expression: generated
+---
+// This file is generated. Do not edit it manually.
+use crate::prelude::*;
+use std::{
+    fmt::Display,
+    ops::{Deref, Range},
+    slice::Iter,
+    str::FromStr,
+};
+
+static LANG_DATA: &[u8] = include_bytes!("attrib_only_gen.ftl");
+
+static ALL_LANGS: [L10n; 1] = [
+    // languages as an array
+    L10n::En,
+];
+
+static EN: LanguageIdentifier = langid!("en");
+
+/// The languages that have translations available.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum L10n {
+    En,
+}
+
+impl Default for L10n {
+    fn default() -> Self {
+        Self::En
+    }
+}
+
+impl FromStr for L10n {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "en" => Ok(Self::En),
+            _ => Err(format!("Unknown language: {}", s)),
+        }
+    }
+}
+
+impl Deref for L10n {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::En => "en",
+        }
+    }
+}
+
+impl AsRef<LanguageIdentifier> for L10n {
+    fn as_ref(&self) -> &LanguageIdentifier {
+        match self {
+            Self::En => &EN,
+        }
+    }
+}
+
+impl AsRef<str> for L10n {
+    fn as_ref(&self) -> &str {
+        self
+    }
+}
+
+impl Display for L10n {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.deref())
+    }
+}
+
+impl L10n {
+    pub fn iter() -> Iter<'static, L10n> {
+        ALL_LANGS.iter()
+    }
+
+    /// Negotiate the best language to use based on the `Accept-Language` header.
+    ///
+    /// Falls back to the default language if none of the languages in the header are available.
+    pub fn langneg(accept_language: &str) -> L10n {
+        negotiate_languages(accept_language, &ALL_LANGS)
+    }
+
+    fn byte_range(&self) -> Range<usize> {
+        match self {
+            Self::En => 0..87,
+        }
+    }
+    /// Load a L10nLanguage from the embedded data.
+    pub fn load(&self) -> L10nLanguage {
+        let bytes = LANG_DATA[self.byte_range()].to_vec();
+        L10nLanguage::new(self, &bytes).unwrap()
+    }
+
+    /// Load all languages (L10nLanguage) from the embedded data.
+    pub fn load_all() -> L10nLanguageVec {
+        L10nLanguageVec::load(
+            LANG_DATA,
+            Self::iter().map(|lang| (lang, lang.byte_range())),
+        )
+        .unwrap()
+    }
+}
+
+/// A thin wrapper around the Fluent messages for one language.
+///
+/// It provides functions for each message that was found in
+/// all the languages at build time.
+pub struct L10nLanguage(L10nBundle);
+
+impl L10nLanguage {
+    /// Load the L10n resources for the given language. The language
+    /// has to be a valid LanguageIdentifier or otherwise
+    /// an error is returned.
+    ///
+    /// The bytes are expected to be the contents of a .ftl file
+    pub fn new(lang: impl AsRef<str>, bytes: &[u8]) -> Result<Self, String> {
+        Ok(Self(L10nBundle::new(lang, bytes)?))
+    }
+
+    pub fn msg_hello_tooltip<'a, F0: Into<FluentValue<'a>>>(&self, user_name: F0) -> String {
+        let mut args = FluentArgs::new();
+        args.set("userName", user_name);
+        self.0.attr("hello", "tooltip", Some(args)).unwrap()
+    }
+}

--- a/src/tests/snapshots/fluent_typed__tests__complex.snap
+++ b/src/tests/snapshots/fluent_typed__tests__complex.snap
@@ -1,0 +1,129 @@
+---
+source: src/tests/mod.rs
+expression: generated
+---
+// This file is generated. Do not edit it manually.
+use crate::prelude::*;
+use std::{
+    fmt::Display,
+    ops::{Deref, Range},
+    slice::Iter,
+    str::FromStr,
+};
+
+static LANG_DATA: &[u8] = include_bytes!("complex_gen.ftl");
+
+static ALL_LANGS: [L10n; 1] = [
+    // languages as an array
+    L10n::En,
+];
+
+static EN: LanguageIdentifier = langid!("en");
+
+/// The languages that have translations available.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum L10n {
+    En,
+}
+
+impl Default for L10n {
+    fn default() -> Self {
+        Self::En
+    }
+}
+
+impl FromStr for L10n {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "en" => Ok(Self::En),
+            _ => Err(format!("Unknown language: {}", s)),
+        }
+    }
+}
+
+impl Deref for L10n {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::En => "en",
+        }
+    }
+}
+
+impl AsRef<LanguageIdentifier> for L10n {
+    fn as_ref(&self) -> &LanguageIdentifier {
+        match self {
+            Self::En => &EN,
+        }
+    }
+}
+
+impl AsRef<str> for L10n {
+    fn as_ref(&self) -> &str {
+        self
+    }
+}
+
+impl Display for L10n {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.deref())
+    }
+}
+
+impl L10n {
+    pub fn iter() -> Iter<'static, L10n> {
+        ALL_LANGS.iter()
+    }
+
+    /// Negotiate the best language to use based on the `Accept-Language` header.
+    ///
+    /// Falls back to the default language if none of the languages in the header are available.
+    pub fn langneg(accept_language: &str) -> L10n {
+        negotiate_languages(accept_language, &ALL_LANGS)
+    }
+
+    fn byte_range(&self) -> Range<usize> {
+        match self {
+            Self::En => 0..67,
+        }
+    }
+    /// Load a L10nLanguage from the embedded data.
+    pub fn load(&self) -> L10nLanguage {
+        let bytes = LANG_DATA[self.byte_range()].to_vec();
+        L10nLanguage::new(self, &bytes).unwrap()
+    }
+
+    /// Load all languages (L10nLanguage) from the embedded data.
+    pub fn load_all() -> L10nLanguageVec {
+        L10nLanguageVec::load(
+            LANG_DATA,
+            Self::iter().map(|lang| (lang, lang.byte_range())),
+        )
+        .unwrap()
+    }
+}
+
+/// A thin wrapper around the Fluent messages for one language.
+///
+/// It provides functions for each message that was found in
+/// all the languages at build time.
+pub struct L10nLanguage(L10nBundle);
+
+impl L10nLanguage {
+    /// Load the L10n resources for the given language. The language
+    /// has to be a valid LanguageIdentifier or otherwise
+    /// an error is returned.
+    ///
+    /// The bytes are expected to be the contents of a .ftl file
+    pub fn new(lang: impl AsRef<str>, bytes: &[u8]) -> Result<Self, String> {
+        Ok(Self(L10nBundle::new(lang, bytes)?))
+    }
+
+    pub fn msg_key<'a, F0: Into<FluentValue<'a>>>(&self, var: F0) -> String {
+        let mut args = FluentArgs::new();
+        args.set("var", var);
+        self.0.msg("key", Some(args)).unwrap()
+    }
+}

--- a/src/tests/snapshots/fluent_typed__tests__msg_number.snap
+++ b/src/tests/snapshots/fluent_typed__tests__msg_number.snap
@@ -1,0 +1,130 @@
+---
+source: src/tests/mod.rs
+expression: generated
+---
+// This file is generated. Do not edit it manually.
+use crate::prelude::*;
+use std::{
+    fmt::Display,
+    ops::{Deref, Range},
+    slice::Iter,
+    str::FromStr,
+};
+
+static LANG_DATA: &[u8] = include_bytes!("msg_number_gen.ftl");
+
+static ALL_LANGS: [L10n; 1] = [
+    // languages as an array
+    L10n::En,
+];
+
+static EN: LanguageIdentifier = langid!("en");
+
+/// The languages that have translations available.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum L10n {
+    En,
+}
+
+impl Default for L10n {
+    fn default() -> Self {
+        Self::En
+    }
+}
+
+impl FromStr for L10n {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "en" => Ok(Self::En),
+            _ => Err(format!("Unknown language: {}", s)),
+        }
+    }
+}
+
+impl Deref for L10n {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::En => "en",
+        }
+    }
+}
+
+impl AsRef<LanguageIdentifier> for L10n {
+    fn as_ref(&self) -> &LanguageIdentifier {
+        match self {
+            Self::En => &EN,
+        }
+    }
+}
+
+impl AsRef<str> for L10n {
+    fn as_ref(&self) -> &str {
+        self
+    }
+}
+
+impl Display for L10n {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.deref())
+    }
+}
+
+impl L10n {
+    pub fn iter() -> Iter<'static, L10n> {
+        ALL_LANGS.iter()
+    }
+
+    /// Negotiate the best language to use based on the `Accept-Language` header.
+    ///
+    /// Falls back to the default language if none of the languages in the header are available.
+    pub fn langneg(accept_language: &str) -> L10n {
+        negotiate_languages(accept_language, &ALL_LANGS)
+    }
+
+    fn byte_range(&self) -> Range<usize> {
+        match self {
+            Self::En => 0..96,
+        }
+    }
+    /// Load a L10nLanguage from the embedded data.
+    pub fn load(&self) -> L10nLanguage {
+        let bytes = LANG_DATA[self.byte_range()].to_vec();
+        L10nLanguage::new(self, &bytes).unwrap()
+    }
+
+    /// Load all languages (L10nLanguage) from the embedded data.
+    pub fn load_all() -> L10nLanguageVec {
+        L10nLanguageVec::load(
+            LANG_DATA,
+            Self::iter().map(|lang| (lang, lang.byte_range())),
+        )
+        .unwrap()
+    }
+}
+
+/// A thin wrapper around the Fluent messages for one language.
+///
+/// It provides functions for each message that was found in
+/// all the languages at build time.
+pub struct L10nLanguage(L10nBundle);
+
+impl L10nLanguage {
+    /// Load the L10n resources for the given language. The language
+    /// has to be a valid LanguageIdentifier or otherwise
+    /// an error is returned.
+    ///
+    /// The bytes are expected to be the contents of a .ftl file
+    pub fn new(lang: impl AsRef<str>, bytes: &[u8]) -> Result<Self, String> {
+        Ok(Self(L10nBundle::new(lang, bytes)?))
+    }
+
+    /// $duration (Number) - The duration in seconds.
+    pub fn msg_time_elapsed<F0: Into<FluentNumber>>(&self, duration: F0) -> String {
+        let mut args = FluentArgs::new();
+        args.set("duration", duration.into());
+        self.0.msg("time-elapsed", Some(args)).unwrap()
+    }
+}

--- a/src/tests/snapshots/fluent_typed__tests__msg_string.snap
+++ b/src/tests/snapshots/fluent_typed__tests__msg_string.snap
@@ -1,0 +1,130 @@
+---
+source: src/tests/mod.rs
+expression: generated
+---
+// This file is generated. Do not edit it manually.
+use crate::prelude::*;
+use std::{
+    fmt::Display,
+    ops::{Deref, Range},
+    slice::Iter,
+    str::FromStr,
+};
+
+static LANG_DATA: &[u8] = include_bytes!("msg_string_gen.ftl");
+
+static ALL_LANGS: [L10n; 1] = [
+    // languages as an array
+    L10n::En,
+];
+
+static EN: LanguageIdentifier = langid!("en");
+
+/// The languages that have translations available.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum L10n {
+    En,
+}
+
+impl Default for L10n {
+    fn default() -> Self {
+        Self::En
+    }
+}
+
+impl FromStr for L10n {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "en" => Ok(Self::En),
+            _ => Err(format!("Unknown language: {}", s)),
+        }
+    }
+}
+
+impl Deref for L10n {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::En => "en",
+        }
+    }
+}
+
+impl AsRef<LanguageIdentifier> for L10n {
+    fn as_ref(&self) -> &LanguageIdentifier {
+        match self {
+            Self::En => &EN,
+        }
+    }
+}
+
+impl AsRef<str> for L10n {
+    fn as_ref(&self) -> &str {
+        self
+    }
+}
+
+impl Display for L10n {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.deref())
+    }
+}
+
+impl L10n {
+    pub fn iter() -> Iter<'static, L10n> {
+        ALL_LANGS.iter()
+    }
+
+    /// Negotiate the best language to use based on the `Accept-Language` header.
+    ///
+    /// Falls back to the default language if none of the languages in the header are available.
+    pub fn langneg(accept_language: &str) -> L10n {
+        negotiate_languages(accept_language, &ALL_LANGS)
+    }
+
+    fn byte_range(&self) -> Range<usize> {
+        match self {
+            Self::En => 0..56,
+        }
+    }
+    /// Load a L10nLanguage from the embedded data.
+    pub fn load(&self) -> L10nLanguage {
+        let bytes = LANG_DATA[self.byte_range()].to_vec();
+        L10nLanguage::new(self, &bytes).unwrap()
+    }
+
+    /// Load all languages (L10nLanguage) from the embedded data.
+    pub fn load_all() -> L10nLanguageVec {
+        L10nLanguageVec::load(
+            LANG_DATA,
+            Self::iter().map(|lang| (lang, lang.byte_range())),
+        )
+        .unwrap()
+    }
+}
+
+/// A thin wrapper around the Fluent messages for one language.
+///
+/// It provides functions for each message that was found in
+/// all the languages at build time.
+pub struct L10nLanguage(L10nBundle);
+
+impl L10nLanguage {
+    /// Load the L10n resources for the given language. The language
+    /// has to be a valid LanguageIdentifier or otherwise
+    /// an error is returned.
+    ///
+    /// The bytes are expected to be the contents of a .ftl file
+    pub fn new(lang: impl AsRef<str>, bytes: &[u8]) -> Result<Self, String> {
+        Ok(Self(L10nBundle::new(lang, bytes)?))
+    }
+
+    /// $name (String) - The name.
+    pub fn msg_greeting<F0: AsRef<str>>(&self, name: F0) -> String {
+        let mut args = FluentArgs::new();
+        args.set("name", name.as_ref());
+        self.0.msg("greeting", Some(args)).unwrap()
+    }
+}

--- a/src/tests/snapshots/fluent_typed__tests__msg_text.snap
+++ b/src/tests/snapshots/fluent_typed__tests__msg_text.snap
@@ -1,3 +1,7 @@
+---
+source: src/tests/mod.rs
+expression: generated
+---
 // This file is generated. Do not edit it manually.
 use crate::prelude::*;
 use std::{
@@ -7,20 +11,24 @@ use std::{
     str::FromStr,
 };
 
-static LANG_DATA: &[u8] = include_bytes!("./ftl.bin"); // <<placeholder lang_data>>
-static ALL_LANGS: [L10n; 1] = [L10n::Placeholder]; // <<placeholder all_langs>>
+static LANG_DATA: &[u8] = include_bytes!("msg_text_gen.ftl");
 
-// <<placeholder static enum langid>>
+static ALL_LANGS: [L10n; 1] = [
+    // languages as an array
+    L10n::En,
+];
+
+static EN: LanguageIdentifier = langid!("en");
 
 /// The languages that have translations available.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum L10n {
-    Placeholder, // <<placeholder enum variant>>
+    En,
 }
 
 impl Default for L10n {
     fn default() -> Self {
-        Self::Placeholder // <<placeholder default lang>>
+        Self::En
     }
 }
 
@@ -29,7 +37,7 @@ impl FromStr for L10n {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "placeholder" => Ok(Self::Placeholder), // <<placeholder enum from_str>>
+            "en" => Ok(Self::En),
             _ => Err(format!("Unknown language: {}", s)),
         }
     }
@@ -39,12 +47,19 @@ impl Deref for L10n {
     type Target = str;
     fn deref(&self) -> &Self::Target {
         match self {
-            Self::Placeholder => "placeholder", // <<placeholder enum to_str>>
+            Self::En => "en",
         }
     }
 }
 
-// <<placeholder as_ref_langid>>
+impl AsRef<LanguageIdentifier> for L10n {
+    fn as_ref(&self) -> &LanguageIdentifier {
+        match self {
+            Self::En => &EN,
+        }
+    }
+}
+
 impl AsRef<str> for L10n {
     fn as_ref(&self) -> &str {
         self
@@ -61,9 +76,33 @@ impl L10n {
     pub fn iter() -> Iter<'static, L10n> {
         ALL_LANGS.iter()
     }
-    // <<placeholder lang_name function>>
-    // <<placeholder langneg function>>
-    // <<placeholder load functions>>
+
+    /// Negotiate the best language to use based on the `Accept-Language` header.
+    ///
+    /// Falls back to the default language if none of the languages in the header are available.
+    pub fn langneg(accept_language: &str) -> L10n {
+        negotiate_languages(accept_language, &ALL_LANGS)
+    }
+
+    fn byte_range(&self) -> Range<usize> {
+        match self {
+            Self::En => 0..30,
+        }
+    }
+    /// Load a L10nLanguage from the embedded data.
+    pub fn load(&self) -> L10nLanguage {
+        let bytes = LANG_DATA[self.byte_range()].to_vec();
+        L10nLanguage::new(self, &bytes).unwrap()
+    }
+
+    /// Load all languages (L10nLanguage) from the embedded data.
+    pub fn load_all() -> L10nLanguageVec {
+        L10nLanguageVec::load(
+            LANG_DATA,
+            Self::iter().map(|lang| (lang, lang.byte_range())),
+        )
+        .unwrap()
+    }
 }
 
 /// A thin wrapper around the Fluent messages for one language.
@@ -79,8 +118,10 @@ impl L10nLanguage {
     ///
     /// The bytes are expected to be the contents of a .ftl file
     pub fn new(lang: impl AsRef<str>, bytes: &[u8]) -> Result<Self, String> {
-        Ok(Self(L10nBundle::new(lang, bytes)?)) // <<placeholder l10n bundle new>>
+        Ok(Self(L10nBundle::new(lang, bytes)?))
     }
 
-    // <<message implementations>>
+    pub fn msg_hello_world(&self) -> String {
+        self.0.msg("hello-world", None).unwrap()
+    }
 }

--- a/src/tests/snapshots/fluent_typed__tests__msg_text_both.snap
+++ b/src/tests/snapshots/fluent_typed__tests__msg_text_both.snap
@@ -1,0 +1,130 @@
+---
+source: src/tests/mod.rs
+expression: generated
+---
+// This file is generated. Do not edit it manually.
+use crate::prelude::*;
+use std::{
+    fmt::Display,
+    ops::{Deref, Range},
+    slice::Iter,
+    str::FromStr,
+};
+
+static LANG_DATA: &[u8] = include_bytes!("msg_text_both_gen.ftl");
+
+static ALL_LANGS: [L10n; 1] = [
+    // languages as an array
+    L10n::En,
+];
+
+static EN: LanguageIdentifier = langid!("en");
+
+/// The languages that have translations available.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum L10n {
+    En,
+}
+
+impl Default for L10n {
+    fn default() -> Self {
+        Self::En
+    }
+}
+
+impl FromStr for L10n {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "en" => Ok(Self::En),
+            _ => Err(format!("Unknown language: {}", s)),
+        }
+    }
+}
+
+impl Deref for L10n {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::En => "en",
+        }
+    }
+}
+
+impl AsRef<LanguageIdentifier> for L10n {
+    fn as_ref(&self) -> &LanguageIdentifier {
+        match self {
+            Self::En => &EN,
+        }
+    }
+}
+
+impl AsRef<str> for L10n {
+    fn as_ref(&self) -> &str {
+        self
+    }
+}
+
+impl Display for L10n {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.deref())
+    }
+}
+
+impl L10n {
+    pub fn iter() -> Iter<'static, L10n> {
+        ALL_LANGS.iter()
+    }
+
+    /// Negotiate the best language to use based on the `Accept-Language` header.
+    ///
+    /// Falls back to the default language if none of the languages in the header are available.
+    pub fn langneg(accept_language: &str) -> L10n {
+        negotiate_languages(accept_language, &ALL_LANGS)
+    }
+
+    fn byte_range(&self) -> Range<usize> {
+        match self {
+            Self::En => 0..30,
+        }
+    }
+    /// Load a L10nLanguage from the embedded data.
+    pub fn load(&self) -> L10nLanguage {
+        let bytes = LANG_DATA[self.byte_range()].to_vec();
+        L10nLanguage::new(self, &bytes).unwrap()
+    }
+
+    /// Load all languages (L10nLanguage) from the embedded data.
+    pub fn load_all() -> L10nLanguageVec {
+        L10nLanguageVec::load(
+            LANG_DATA,
+            Self::iter().map(|lang| (lang, lang.byte_range())),
+        )
+        .unwrap()
+    }
+}
+
+/// A thin wrapper around the Fluent messages for one language.
+///
+/// It provides functions for each message that was found in
+/// all the languages at build time.
+pub struct L10nLanguage(L10nBundle);
+
+impl L10nLanguage {
+    /// Load the L10n resources for the given language. The language
+    /// has to be a valid LanguageIdentifier or otherwise
+    /// an error is returned.
+    ///
+    /// The bytes are expected to be the contents of a .ftl file
+    pub fn new(lang: impl AsRef<str>, bytes: &[u8]) -> Result<Self, String> {
+        Ok(Self(L10nBundle::new(lang, bytes)?))
+    }
+
+    pub fn msg_hello_world(&self) -> String {
+        self.0.msg("hello-world", None).unwrap()
+    }
+    pub fn ptn_hello_world(&self) -> Pattern<String> {
+        self.0.msg_pattern("hello-world")
+    }
+}

--- a/src/tests/snapshots/fluent_typed__tests__msg_text_pattern.snap
+++ b/src/tests/snapshots/fluent_typed__tests__msg_text_pattern.snap
@@ -1,0 +1,127 @@
+---
+source: src/tests/mod.rs
+expression: generated
+---
+// This file is generated. Do not edit it manually.
+use crate::prelude::*;
+use std::{
+    fmt::Display,
+    ops::{Deref, Range},
+    slice::Iter,
+    str::FromStr,
+};
+
+static LANG_DATA: &[u8] = include_bytes!("msg_text_pattern_gen.ftl");
+
+static ALL_LANGS: [L10n; 1] = [
+    // languages as an array
+    L10n::En,
+];
+
+static EN: LanguageIdentifier = langid!("en");
+
+/// The languages that have translations available.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum L10n {
+    En,
+}
+
+impl Default for L10n {
+    fn default() -> Self {
+        Self::En
+    }
+}
+
+impl FromStr for L10n {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "en" => Ok(Self::En),
+            _ => Err(format!("Unknown language: {}", s)),
+        }
+    }
+}
+
+impl Deref for L10n {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::En => "en",
+        }
+    }
+}
+
+impl AsRef<LanguageIdentifier> for L10n {
+    fn as_ref(&self) -> &LanguageIdentifier {
+        match self {
+            Self::En => &EN,
+        }
+    }
+}
+
+impl AsRef<str> for L10n {
+    fn as_ref(&self) -> &str {
+        self
+    }
+}
+
+impl Display for L10n {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.deref())
+    }
+}
+
+impl L10n {
+    pub fn iter() -> Iter<'static, L10n> {
+        ALL_LANGS.iter()
+    }
+
+    /// Negotiate the best language to use based on the `Accept-Language` header.
+    ///
+    /// Falls back to the default language if none of the languages in the header are available.
+    pub fn langneg(accept_language: &str) -> L10n {
+        negotiate_languages(accept_language, &ALL_LANGS)
+    }
+
+    fn byte_range(&self) -> Range<usize> {
+        match self {
+            Self::En => 0..30,
+        }
+    }
+    /// Load a L10nLanguage from the embedded data.
+    pub fn load(&self) -> L10nLanguage {
+        let bytes = LANG_DATA[self.byte_range()].to_vec();
+        L10nLanguage::new(self, &bytes).unwrap()
+    }
+
+    /// Load all languages (L10nLanguage) from the embedded data.
+    pub fn load_all() -> L10nLanguageVec {
+        L10nLanguageVec::load(
+            LANG_DATA,
+            Self::iter().map(|lang| (lang, lang.byte_range())),
+        )
+        .unwrap()
+    }
+}
+
+/// A thin wrapper around the Fluent messages for one language.
+///
+/// It provides functions for each message that was found in
+/// all the languages at build time.
+pub struct L10nLanguage(L10nBundle);
+
+impl L10nLanguage {
+    /// Load the L10n resources for the given language. The language
+    /// has to be a valid LanguageIdentifier or otherwise
+    /// an error is returned.
+    ///
+    /// The bytes are expected to be the contents of a .ftl file
+    pub fn new(lang: impl AsRef<str>, bytes: &[u8]) -> Result<Self, String> {
+        Ok(Self(L10nBundle::new(lang, bytes)?))
+    }
+
+    pub fn ptn_hello_world(&self) -> Pattern<String> {
+        self.0.msg_pattern("hello-world")
+    }
+}

--- a/src/tests/snapshots/fluent_typed__tests__msg_with_attrib.snap
+++ b/src/tests/snapshots/fluent_typed__tests__msg_with_attrib.snap
@@ -1,0 +1,133 @@
+---
+source: src/tests/mod.rs
+expression: generated
+---
+// This file is generated. Do not edit it manually.
+use crate::prelude::*;
+use std::{
+    fmt::Display,
+    ops::{Deref, Range},
+    slice::Iter,
+    str::FromStr,
+};
+
+static LANG_DATA: &[u8] = include_bytes!("msg_with_attrib_gen.ftl");
+
+static ALL_LANGS: [L10n; 1] = [
+    // languages as an array
+    L10n::En,
+];
+
+static EN: LanguageIdentifier = langid!("en");
+
+/// The languages that have translations available.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum L10n {
+    En,
+}
+
+impl Default for L10n {
+    fn default() -> Self {
+        Self::En
+    }
+}
+
+impl FromStr for L10n {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "en" => Ok(Self::En),
+            _ => Err(format!("Unknown language: {}", s)),
+        }
+    }
+}
+
+impl Deref for L10n {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::En => "en",
+        }
+    }
+}
+
+impl AsRef<LanguageIdentifier> for L10n {
+    fn as_ref(&self) -> &LanguageIdentifier {
+        match self {
+            Self::En => &EN,
+        }
+    }
+}
+
+impl AsRef<str> for L10n {
+    fn as_ref(&self) -> &str {
+        self
+    }
+}
+
+impl Display for L10n {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.deref())
+    }
+}
+
+impl L10n {
+    pub fn iter() -> Iter<'static, L10n> {
+        ALL_LANGS.iter()
+    }
+
+    /// Negotiate the best language to use based on the `Accept-Language` header.
+    ///
+    /// Falls back to the default language if none of the languages in the header are available.
+    pub fn langneg(accept_language: &str) -> L10n {
+        negotiate_languages(accept_language, &ALL_LANGS)
+    }
+
+    fn byte_range(&self) -> Range<usize> {
+        match self {
+            Self::En => 0..99,
+        }
+    }
+    /// Load a L10nLanguage from the embedded data.
+    pub fn load(&self) -> L10nLanguage {
+        let bytes = LANG_DATA[self.byte_range()].to_vec();
+        L10nLanguage::new(self, &bytes).unwrap()
+    }
+
+    /// Load all languages (L10nLanguage) from the embedded data.
+    pub fn load_all() -> L10nLanguageVec {
+        L10nLanguageVec::load(
+            LANG_DATA,
+            Self::iter().map(|lang| (lang, lang.byte_range())),
+        )
+        .unwrap()
+    }
+}
+
+/// A thin wrapper around the Fluent messages for one language.
+///
+/// It provides functions for each message that was found in
+/// all the languages at build time.
+pub struct L10nLanguage(L10nBundle);
+
+impl L10nLanguage {
+    /// Load the L10n resources for the given language. The language
+    /// has to be a valid LanguageIdentifier or otherwise
+    /// an error is returned.
+    ///
+    /// The bytes are expected to be the contents of a .ftl file
+    pub fn new(lang: impl AsRef<str>, bytes: &[u8]) -> Result<Self, String> {
+        Ok(Self(L10nBundle::new(lang, bytes)?))
+    }
+
+    /// This is a message comment
+    pub fn msg_hello(&self) -> String {
+        self.0.msg("hello", None).unwrap()
+    }
+    pub fn msg_hello_tooltip<'a, F0: Into<FluentValue<'a>>>(&self, user_name: F0) -> String {
+        let mut args = FluentArgs::new();
+        args.set("userName", user_name);
+        self.0.attr("hello", "tooltip", Some(args)).unwrap()
+    }
+}

--- a/src/tests/snapshots/fluent_typed__tests__msg_with_var.snap
+++ b/src/tests/snapshots/fluent_typed__tests__msg_with_var.snap
@@ -1,0 +1,129 @@
+---
+source: src/tests/mod.rs
+expression: generated
+---
+// This file is generated. Do not edit it manually.
+use crate::prelude::*;
+use std::{
+    fmt::Display,
+    ops::{Deref, Range},
+    slice::Iter,
+    str::FromStr,
+};
+
+static LANG_DATA: &[u8] = include_bytes!("msg_with_var_gen.ftl");
+
+static ALL_LANGS: [L10n; 1] = [
+    // languages as an array
+    L10n::En,
+];
+
+static EN: LanguageIdentifier = langid!("en");
+
+/// The languages that have translations available.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum L10n {
+    En,
+}
+
+impl Default for L10n {
+    fn default() -> Self {
+        Self::En
+    }
+}
+
+impl FromStr for L10n {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "en" => Ok(Self::En),
+            _ => Err(format!("Unknown language: {}", s)),
+        }
+    }
+}
+
+impl Deref for L10n {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::En => "en",
+        }
+    }
+}
+
+impl AsRef<LanguageIdentifier> for L10n {
+    fn as_ref(&self) -> &LanguageIdentifier {
+        match self {
+            Self::En => &EN,
+        }
+    }
+}
+
+impl AsRef<str> for L10n {
+    fn as_ref(&self) -> &str {
+        self
+    }
+}
+
+impl Display for L10n {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.deref())
+    }
+}
+
+impl L10n {
+    pub fn iter() -> Iter<'static, L10n> {
+        ALL_LANGS.iter()
+    }
+
+    /// Negotiate the best language to use based on the `Accept-Language` header.
+    ///
+    /// Falls back to the default language if none of the languages in the header are available.
+    pub fn langneg(accept_language: &str) -> L10n {
+        negotiate_languages(accept_language, &ALL_LANGS)
+    }
+
+    fn byte_range(&self) -> Range<usize> {
+        match self {
+            Self::En => 0..31,
+        }
+    }
+    /// Load a L10nLanguage from the embedded data.
+    pub fn load(&self) -> L10nLanguage {
+        let bytes = LANG_DATA[self.byte_range()].to_vec();
+        L10nLanguage::new(self, &bytes).unwrap()
+    }
+
+    /// Load all languages (L10nLanguage) from the embedded data.
+    pub fn load_all() -> L10nLanguageVec {
+        L10nLanguageVec::load(
+            LANG_DATA,
+            Self::iter().map(|lang| (lang, lang.byte_range())),
+        )
+        .unwrap()
+    }
+}
+
+/// A thin wrapper around the Fluent messages for one language.
+///
+/// It provides functions for each message that was found in
+/// all the languages at build time.
+pub struct L10nLanguage(L10nBundle);
+
+impl L10nLanguage {
+    /// Load the L10n resources for the given language. The language
+    /// has to be a valid LanguageIdentifier or otherwise
+    /// an error is returned.
+    ///
+    /// The bytes are expected to be the contents of a .ftl file
+    pub fn new(lang: impl AsRef<str>, bytes: &[u8]) -> Result<Self, String> {
+        Ok(Self(L10nBundle::new(lang, bytes)?))
+    }
+
+    pub fn msg_hello<'a, F0: Into<FluentValue<'a>>>(&self, first_name: F0) -> String {
+        let mut args = FluentArgs::new();
+        args.set("first-name", first_name);
+        self.0.msg("hello", Some(args)).unwrap()
+    }
+}

--- a/src/tests/snapshots/fluent_typed__tests__res_msg_text.snap
+++ b/src/tests/snapshots/fluent_typed__tests__res_msg_text.snap
@@ -1,3 +1,7 @@
+---
+source: src/tests/mod.rs
+expression: generated
+---
 // This file is generated. Do not edit it manually.
 use crate::prelude::*;
 use std::{
@@ -7,20 +11,24 @@ use std::{
     str::FromStr,
 };
 
-static LANG_DATA: &[u8] = include_bytes!("./ftl.bin"); // <<placeholder lang_data>>
-static ALL_LANGS: [L10n; 1] = [L10n::Placeholder]; // <<placeholder all_langs>>
+static LANG_DATA: &[u8] = include_bytes!("res_msg_text_gen.ftl");
 
-// <<placeholder static enum langid>>
+static ALL_LANGS: [L10n; 1] = [
+    // languages as an array
+    L10n::En,
+];
+
+static EN: LanguageIdentifier = langid!("en");
 
 /// The languages that have translations available.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum L10n {
-    Placeholder, // <<placeholder enum variant>>
+    En,
 }
 
 impl Default for L10n {
     fn default() -> Self {
-        Self::Placeholder // <<placeholder default lang>>
+        Self::En
     }
 }
 
@@ -29,7 +37,7 @@ impl FromStr for L10n {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "placeholder" => Ok(Self::Placeholder), // <<placeholder enum from_str>>
+            "en" => Ok(Self::En),
             _ => Err(format!("Unknown language: {}", s)),
         }
     }
@@ -39,12 +47,19 @@ impl Deref for L10n {
     type Target = str;
     fn deref(&self) -> &Self::Target {
         match self {
-            Self::Placeholder => "placeholder", // <<placeholder enum to_str>>
+            Self::En => "en",
         }
     }
 }
 
-// <<placeholder as_ref_langid>>
+impl AsRef<LanguageIdentifier> for L10n {
+    fn as_ref(&self) -> &LanguageIdentifier {
+        match self {
+            Self::En => &EN,
+        }
+    }
+}
+
 impl AsRef<str> for L10n {
     fn as_ref(&self) -> &str {
         self
@@ -61,9 +76,33 @@ impl L10n {
     pub fn iter() -> Iter<'static, L10n> {
         ALL_LANGS.iter()
     }
-    // <<placeholder lang_name function>>
-    // <<placeholder langneg function>>
-    // <<placeholder load functions>>
+
+    /// Negotiate the best language to use based on the `Accept-Language` header.
+    ///
+    /// Falls back to the default language if none of the languages in the header are available.
+    pub fn langneg(accept_language: &str) -> L10n {
+        negotiate_languages(accept_language, &ALL_LANGS)
+    }
+
+    fn byte_range(&self) -> Range<usize> {
+        match self {
+            Self::En => 0..30,
+        }
+    }
+    /// Load a L10nLanguage from the embedded data.
+    pub fn load(&self) -> L10nLanguage {
+        let bytes = LANG_DATA[self.byte_range()].to_vec();
+        L10nLanguage::new(self, &bytes).unwrap()
+    }
+
+    /// Load all languages (L10nLanguage) from the embedded data.
+    pub fn load_all() -> L10nLanguageVec {
+        L10nLanguageVec::load(
+            LANG_DATA,
+            Self::iter().map(|lang| (lang, lang.byte_range())),
+        )
+        .unwrap()
+    }
 }
 
 /// A thin wrapper around the Fluent messages for one language.
@@ -79,8 +118,10 @@ impl L10nLanguage {
     ///
     /// The bytes are expected to be the contents of a .ftl file
     pub fn new(lang: impl AsRef<str>, bytes: &[u8]) -> Result<Self, String> {
-        Ok(Self(L10nBundle::new(lang, bytes)?)) // <<placeholder l10n bundle new>>
+        Ok(Self(L10nBundle::new(lang, bytes)?))
     }
 
-    // <<message implementations>>
+    pub fn msg_hello_world(&self) -> String {
+        self.0.msg("hello-world", None).unwrap()
+    }
 }

--- a/src/tests/snapshots/fluent_typed__tests__test_locales.snap
+++ b/src/tests/snapshots/fluent_typed__tests__test_locales.snap
@@ -1,0 +1,137 @@
+---
+source: src/tests/mod.rs
+expression: generated
+---
+// This file is generated. Do not edit it manually.
+use crate::prelude::*;
+use std::{
+    fmt::Display,
+    ops::{Deref, Range},
+    slice::Iter,
+    str::FromStr,
+};
+
+static LANG_DATA: &[u8] = include_bytes!("test_locales.ftl");
+
+static ALL_LANGS: [L10n; 2] = [
+    // languages as an array
+    L10n::De,
+    L10n::EnGb,
+];
+
+static DE: LanguageIdentifier = langid!("de");
+static EN_GB: LanguageIdentifier = langid!("en-gb");
+
+/// The languages that have translations available.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum L10n {
+    De,
+    EnGb,
+}
+
+impl Default for L10n {
+    fn default() -> Self {
+        Self::EnGb
+    }
+}
+
+impl FromStr for L10n {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "de" => Ok(Self::De),
+            "en-gb" => Ok(Self::EnGb),
+            _ => Err(format!("Unknown language: {}", s)),
+        }
+    }
+}
+
+impl Deref for L10n {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::De => "de",
+            Self::EnGb => "en-gb",
+        }
+    }
+}
+
+impl AsRef<LanguageIdentifier> for L10n {
+    fn as_ref(&self) -> &LanguageIdentifier {
+        match self {
+            Self::De => &DE,
+            Self::EnGb => &EN_GB,
+        }
+    }
+}
+
+impl AsRef<str> for L10n {
+    fn as_ref(&self) -> &str {
+        self
+    }
+}
+
+impl Display for L10n {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.deref())
+    }
+}
+
+impl L10n {
+    pub fn iter() -> Iter<'static, L10n> {
+        ALL_LANGS.iter()
+    }
+
+    /// Negotiate the best language to use based on the `Accept-Language` header.
+    ///
+    /// Falls back to the default language if none of the languages in the header are available.
+    pub fn langneg(accept_language: &str) -> L10n {
+        negotiate_languages(accept_language, &ALL_LANGS)
+    }
+
+    fn byte_range(&self) -> Range<usize> {
+        match self {
+            Self::De => 0..107,
+            Self::EnGb => 107..208,
+        }
+    }
+    /// Load a L10nLanguage from the embedded data.
+    pub fn load(&self) -> L10nLanguage {
+        let bytes = LANG_DATA[self.byte_range()].to_vec();
+        L10nLanguage::new(self, &bytes).unwrap()
+    }
+
+    /// Load all languages (L10nLanguage) from the embedded data.
+    pub fn load_all() -> L10nLanguageVec {
+        L10nLanguageVec::load(
+            LANG_DATA,
+            Self::iter().map(|lang| (lang, lang.byte_range())),
+        )
+        .unwrap()
+    }
+}
+
+/// A thin wrapper around the Fluent messages for one language.
+///
+/// It provides functions for each message that was found in
+/// all the languages at build time.
+pub struct L10nLanguage(L10nBundle);
+
+impl L10nLanguage {
+    /// Load the L10n resources for the given language. The language
+    /// has to be a valid LanguageIdentifier or otherwise
+    /// an error is returned.
+    ///
+    /// The bytes are expected to be the contents of a .ftl file
+    pub fn new(lang: impl AsRef<str>, bytes: &[u8]) -> Result<Self, String> {
+        Ok(Self(L10nBundle::new(lang, bytes)?))
+    }
+
+    pub fn msg_twenty_four_hour(&self) -> String {
+        self.0.msg("twenty-four-hour", None).unwrap()
+    }
+    pub fn msg_twelve_hour(&self) -> String {
+        self.0.msg("twelve-hour", None).unwrap()
+    }
+}

--- a/src/tests/snapshots/fluent_typed__tests__test_locales_deep_folders.snap
+++ b/src/tests/snapshots/fluent_typed__tests__test_locales_deep_folders.snap
@@ -1,0 +1,164 @@
+---
+source: src/tests/mod.rs
+expression: "&generated"
+---
+// This file is generated. Do not edit it manually.
+use crate::prelude::*;
+use std::{
+    fmt::Display,
+    ops::{Deref, Range},
+    slice::Iter,
+    str::FromStr,
+};
+
+static LANG_DATA: &[u8] = include_bytes!("test_locales_deep_folders.ftl");
+
+static ALL_LANGS: [L10n; 2] = [
+    // languages as an array
+    L10n::De,
+    L10n::En,
+];
+
+static DE: LanguageIdentifier = langid!("de");
+static EN: LanguageIdentifier = langid!("en");
+
+/// The languages that have translations available.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum L10n {
+    De,
+    En,
+}
+
+impl Default for L10n {
+    fn default() -> Self {
+        Self::En
+    }
+}
+
+impl FromStr for L10n {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "de" => Ok(Self::De),
+            "en" => Ok(Self::En),
+            _ => Err(format!("Unknown language: {}", s)),
+        }
+    }
+}
+
+impl Deref for L10n {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::De => "de",
+            Self::En => "en",
+        }
+    }
+}
+
+impl AsRef<LanguageIdentifier> for L10n {
+    fn as_ref(&self) -> &LanguageIdentifier {
+        match self {
+            Self::De => &DE,
+            Self::En => &EN,
+        }
+    }
+}
+
+impl AsRef<str> for L10n {
+    fn as_ref(&self) -> &str {
+        self
+    }
+}
+
+impl Display for L10n {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.deref())
+    }
+}
+
+impl L10n {
+    pub fn iter() -> Iter<'static, L10n> {
+        ALL_LANGS.iter()
+    }
+
+    /// The language name as defined in the ftl message "language-name".
+    pub fn language_name(&self) -> &'static str {
+        match self {
+            Self::De => "Deutsch",
+            Self::En => "English",
+        }
+    }
+
+    /// Negotiate the best language to use based on the `Accept-Language` header.
+    ///
+    /// Falls back to the default language if none of the languages in the header are available.
+    pub fn langneg(accept_language: &str) -> L10n {
+        negotiate_languages(accept_language, &ALL_LANGS)
+    }
+
+    fn byte_range(&self) -> Range<usize> {
+        match self {
+            Self::De => 0..546,
+            Self::En => 546..1085,
+        }
+    }
+    /// Load a L10nLanguage from the embedded data.
+    pub fn load(&self) -> L10nLanguage {
+        let bytes = LANG_DATA[self.byte_range()].to_vec();
+        L10nLanguage::new(self, &bytes).unwrap()
+    }
+
+    /// Load all languages (L10nLanguage) from the embedded data.
+    pub fn load_all() -> L10nLanguageVec {
+        L10nLanguageVec::load(
+            LANG_DATA,
+            Self::iter().map(|lang| (lang, lang.byte_range())),
+        )
+        .unwrap()
+    }
+}
+
+/// A thin wrapper around the Fluent messages for one language.
+///
+/// It provides functions for each message that was found in
+/// all the languages at build time.
+pub struct L10nLanguage(L10nBundle);
+
+impl L10nLanguage {
+    /// Load the L10n resources for the given language. The language
+    /// has to be a valid LanguageIdentifier or otherwise
+    /// an error is returned.
+    ///
+    /// The bytes are expected to be the contents of a .ftl file
+    pub fn new(lang: impl AsRef<str>, bytes: &[u8]) -> Result<Self, String> {
+        Ok(Self(L10nBundle::new(lang, bytes)?))
+    }
+
+    pub fn msg_level1_hello(&self) -> String {
+        self.0.msg("level1-hello", None).unwrap()
+    }
+    pub fn msg_level1_desc(&self) -> String {
+        self.0.msg("level1-desc", None).unwrap()
+    }
+    pub fn msg_level2_greeting(&self) -> String {
+        self.0.msg("level2-greeting", None).unwrap()
+    }
+    pub fn msg_level2_info(&self) -> String {
+        self.0.msg("level2-info", None).unwrap()
+    }
+    pub fn msg_deep_message(&self) -> String {
+        self.0.msg("deep-message", None).unwrap()
+    }
+    pub fn msg_deep_location(&self) -> String {
+        self.0.msg("deep-location", None).unwrap()
+    }
+    #[allow(unused)]
+    pub fn msg_language_name(&self) -> String {
+        self.0.msg("language-name", None).unwrap()
+    }
+    pub fn msg_root_message(&self) -> String {
+        self.0.msg("root-message", None).unwrap()
+    }
+}

--- a/src/tests/snapshots/fluent_typed__tests__test_locales_missing_msg.snap
+++ b/src/tests/snapshots/fluent_typed__tests__test_locales_missing_msg.snap
@@ -1,0 +1,137 @@
+---
+source: src/tests/mod.rs
+expression: generated
+---
+// This file is generated. Do not edit it manually.
+use crate::prelude::*;
+use std::{
+    fmt::Display,
+    ops::{Deref, Range},
+    slice::Iter,
+    str::FromStr,
+};
+
+static LANG_DATA: &[u8] = include_bytes!("test_locales_missing_msg.ftl");
+
+static ALL_LANGS: [L10n; 2] = [
+    // languages as an array
+    L10n::De,
+    L10n::EnGb,
+];
+
+static DE: LanguageIdentifier = langid!("de");
+static EN_GB: LanguageIdentifier = langid!("en-gb");
+
+/// The languages that have translations available.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum L10n {
+    De,
+    EnGb,
+}
+
+impl Default for L10n {
+    fn default() -> Self {
+        Self::EnGb
+    }
+}
+
+impl FromStr for L10n {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "de" => Ok(Self::De),
+            "en-gb" => Ok(Self::EnGb),
+            _ => Err(format!("Unknown language: {}", s)),
+        }
+    }
+}
+
+impl Deref for L10n {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::De => "de",
+            Self::EnGb => "en-gb",
+        }
+    }
+}
+
+impl AsRef<LanguageIdentifier> for L10n {
+    fn as_ref(&self) -> &LanguageIdentifier {
+        match self {
+            Self::De => &DE,
+            Self::EnGb => &EN_GB,
+        }
+    }
+}
+
+impl AsRef<str> for L10n {
+    fn as_ref(&self) -> &str {
+        self
+    }
+}
+
+impl Display for L10n {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.deref())
+    }
+}
+
+impl L10n {
+    pub fn iter() -> Iter<'static, L10n> {
+        ALL_LANGS.iter()
+    }
+
+    /// Negotiate the best language to use based on the `Accept-Language` header.
+    ///
+    /// Falls back to the default language if none of the languages in the header are available.
+    pub fn langneg(accept_language: &str) -> L10n {
+        negotiate_languages(accept_language, &ALL_LANGS)
+    }
+
+    fn byte_range(&self) -> Range<usize> {
+        match self {
+            Self::De => 0..107,
+            Self::EnGb => 107..208,
+        }
+    }
+    /// Load a L10nLanguage from the embedded data.
+    pub fn load(&self) -> L10nLanguage {
+        let bytes = LANG_DATA[self.byte_range()].to_vec();
+        L10nLanguage::new(self, &bytes).unwrap()
+    }
+
+    /// Load all languages (L10nLanguage) from the embedded data.
+    pub fn load_all() -> L10nLanguageVec {
+        L10nLanguageVec::load(
+            LANG_DATA,
+            Self::iter().map(|lang| (lang, lang.byte_range())),
+        )
+        .unwrap()
+    }
+}
+
+/// A thin wrapper around the Fluent messages for one language.
+///
+/// It provides functions for each message that was found in
+/// all the languages at build time.
+pub struct L10nLanguage(L10nBundle);
+
+impl L10nLanguage {
+    /// Load the L10n resources for the given language. The language
+    /// has to be a valid LanguageIdentifier or otherwise
+    /// an error is returned.
+    ///
+    /// The bytes are expected to be the contents of a .ftl file
+    pub fn new(lang: impl AsRef<str>, bytes: &[u8]) -> Result<Self, String> {
+        Ok(Self(L10nBundle::new(lang, bytes)?))
+    }
+
+    pub fn msg_twenty_four_hour(&self) -> String {
+        self.0.msg("twenty-four-hour", None).unwrap()
+    }
+    pub fn msg_twelve_hour(&self) -> String {
+        self.0.msg("twelve-hour", None).unwrap()
+    }
+}

--- a/src/tests/snapshots/fluent_typed__tests__test_locales_multi_resources.snap
+++ b/src/tests/snapshots/fluent_typed__tests__test_locales_multi_resources.snap
@@ -1,0 +1,137 @@
+---
+source: src/tests/mod.rs
+expression: generated
+---
+// This file is generated. Do not edit it manually.
+use crate::prelude::*;
+use std::{
+    fmt::Display,
+    ops::{Deref, Range},
+    slice::Iter,
+    str::FromStr,
+};
+
+static LANG_DATA: &[u8] = include_bytes!("test_locales_multi_resources.ftl");
+
+static ALL_LANGS: [L10n; 2] = [
+    // languages as an array
+    L10n::De,
+    L10n::EnGb,
+];
+
+static DE: LanguageIdentifier = langid!("de");
+static EN_GB: LanguageIdentifier = langid!("en-gb");
+
+/// The languages that have translations available.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum L10n {
+    De,
+    EnGb,
+}
+
+impl Default for L10n {
+    fn default() -> Self {
+        Self::EnGb
+    }
+}
+
+impl FromStr for L10n {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "de" => Ok(Self::De),
+            "en-gb" => Ok(Self::EnGb),
+            _ => Err(format!("Unknown language: {}", s)),
+        }
+    }
+}
+
+impl Deref for L10n {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::De => "de",
+            Self::EnGb => "en-gb",
+        }
+    }
+}
+
+impl AsRef<LanguageIdentifier> for L10n {
+    fn as_ref(&self) -> &LanguageIdentifier {
+        match self {
+            Self::De => &DE,
+            Self::EnGb => &EN_GB,
+        }
+    }
+}
+
+impl AsRef<str> for L10n {
+    fn as_ref(&self) -> &str {
+        self
+    }
+}
+
+impl Display for L10n {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.deref())
+    }
+}
+
+impl L10n {
+    pub fn iter() -> Iter<'static, L10n> {
+        ALL_LANGS.iter()
+    }
+
+    /// Negotiate the best language to use based on the `Accept-Language` header.
+    ///
+    /// Falls back to the default language if none of the languages in the header are available.
+    pub fn langneg(accept_language: &str) -> L10n {
+        negotiate_languages(accept_language, &ALL_LANGS)
+    }
+
+    fn byte_range(&self) -> Range<usize> {
+        match self {
+            Self::De => 0..148,
+            Self::EnGb => 148..293,
+        }
+    }
+    /// Load a L10nLanguage from the embedded data.
+    pub fn load(&self) -> L10nLanguage {
+        let bytes = LANG_DATA[self.byte_range()].to_vec();
+        L10nLanguage::new(self, &bytes).unwrap()
+    }
+
+    /// Load all languages (L10nLanguage) from the embedded data.
+    pub fn load_all() -> L10nLanguageVec {
+        L10nLanguageVec::load(
+            LANG_DATA,
+            Self::iter().map(|lang| (lang, lang.byte_range())),
+        )
+        .unwrap()
+    }
+}
+
+/// A thin wrapper around the Fluent messages for one language.
+///
+/// It provides functions for each message that was found in
+/// all the languages at build time.
+pub struct L10nLanguage(L10nBundle);
+
+impl L10nLanguage {
+    /// Load the L10n resources for the given language. The language
+    /// has to be a valid LanguageIdentifier or otherwise
+    /// an error is returned.
+    ///
+    /// The bytes are expected to be the contents of a .ftl file
+    pub fn new(lang: impl AsRef<str>, bytes: &[u8]) -> Result<Self, String> {
+        Ok(Self(L10nBundle::new(lang, bytes)?))
+    }
+
+    pub fn msg_greeting(&self) -> String {
+        self.0.msg("greeting", None).unwrap()
+    }
+    pub fn msg_twenty_four_hour(&self) -> String {
+        self.0.msg("twenty-four-hour", None).unwrap()
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up improvements from a code review of the project, in five areas.

### 1. Configurable bidi isolation
The runtime always wrapped interpolated variables in Unicode bidi isolation marks, but the test helper disabled them and the README examples assumed un-isolated output — three inconsistent behaviors.

- Added `L10nBundle::new_without_isolation()`, `L10nLanguageVec::load_without_isolation()`, and `BuildOptions::use_isolating` / `without_bidi_isolation()`.
- Default stays **on** (correct for bidi-aware contexts such as web UIs). Generated output is byte-identical for the default config.

### 2. Runtime tests + empty-folder panic
- Added `src/tests/runtime.rs` with behavioral tests for `L10nBundle` / `L10nLanguageVec` — the message-formatting path previously had no test coverage.
- An empty locales folder now returns `BuildError::NoLocaleFolders` instead of panicking on an `unwrap()`.

### 3. README
- Fixed the corrupted tail (stray `gg`, malformed code fence, unfinished section), stale version numbers, and example code that didn't compile (`L10n::en`, `L10n.iter()`, the `load_all`/`get` example).
- Added a "Bidi isolation" section and an FTL example showcasing core features (typed variables, plural selectors, attributes, `language-name`).

### 4. Snapshot tests
- All code-generation tests now assert their output via `insta` snapshots, so generator changes fail loudly instead of silently rewriting tracked files.

### 5. Cleanups
- Removed the dead `Message.resource` field; documented the `template.rs` / `ftl.bin` dual-use trick; tightened `build` re-export visibility; minor clippy fixes.

## Testing
- 54 unit/integration + 1 playground test pass
- `cargo clippy --all-targets --all-features` clean
- `cargo fmt --check` clean
- builds with `--no-default-features`

## Notes
- **Breaking:** `BuildOptions` gains a `use_isolating` field — affects direct struct construction only (`BuildOptions::default()` users unaffected), consistent with how `deny_duplicate_keys` was added in 0.5.0.
- Found but not fixed here: `L10nLanguageVec::get()` returns the untyped `&L10nBundle`, so `load_all()` doesn't provide typed access. Fixing it needs `L10nLanguageVec` to be generated — worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)