### PR TITLE
FE-909: Add structured `(Element)` messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## Unreleased
 
 ### Added
+- Structured (`(Element)`) messages: annotate a variable or term with
+  `(Element)` to have fluent-typed generate a struct of resolved text segments
+  split at those points, instead of a single `String`. Variable elements are
+  positional gaps the app fills; term elements carry translatable text. Adds
+  `L10nBundle::msg_segments()` and the `Segment` / `ElementGap` prelude types.
 - `BuildOptions::without_bidi_isolation()` and the `BuildOptions::use_isolating`
   field to control whether generated accessors wrap interpolated variables in
   Unicode bidi isolation marks (FSI/PDI). Defaults to enabled.

--- a/README.md
+++ b/README.md
@@ -179,6 +179,45 @@ your-rank = { NUMBER($pos, type: "ordinal") ->
 }
 ```
 
+## Structured messages
+
+Some translations need the app to inject a UI element mid-sentence — an icon, a
+link, a button — without splitting the translated string on a placeholder token.
+Annotate a variable or term with `(Element)` and fluent-typed generates a struct
+of resolved text segments split at those points:
+
+```ftl
+# $count (Number) - How many unread.
+# $icon (Element) - An icon injected by the app.
+# -privacy-link (Element) - Link text the app wraps in an <a>.
+notice = { $icon } You have { $count } unread, see { -privacy-link }.
+-privacy-link = our privacy policy
+```
+
+An `(Element)` **variable** (`$icon`) is a pure positional gap — the app fills it
+with its own element. An `(Element)` **term** (`-privacy-link`) carries
+translatable text the app wraps. The generated accessor returns a struct whose
+fields are the resolved text runs and the element slots, in render order:
+
+```rust
+pub struct Notice {
+    pub s0: String,           // text before $icon
+    pub icon: ElementGap,     // $icon slot — filled by the app
+    pub s1: String,           // text between the elements
+    pub privacy_link: String, // resolved -privacy-link text
+    pub s2: String,           // text after -privacy-link
+}
+
+// $icon / -privacy-link are not parameters; only real arguments are:
+let n: Notice = strs.notice(3);
+// `Notice` also implements `Display`, joining the text for plain-text use.
+```
+
+Selectors and ordinary variables inside each segment are fully resolved, so the
+app never re-implements plural logic. When rendering, wrap each field and each
+injected element in an isolated bidi run (an HTML `<bdi>`, or
+`unicode-bidi: isolate`) — see "Bidi isolation".
+
 ## Bidi isolation
 
 By default, the generated accessors wrap every interpolated variable in Unicode

--- a/src/build/gen/message.rs
+++ b/src/build/gen/message.rs
@@ -1,13 +1,17 @@
 use crate::build::r#gen::StrExt;
 use crate::build::options::OutputMode;
-use crate::build::typed::{Message, VarType, Variable};
+use crate::build::typed::{ElementKind, ElementMarker, Message, VarType, Variable};
 
 impl Message {
     pub fn trait_signature(&self) -> String {
         let mut out = Vec::new();
         let func_name = self.id.func_name();
         out.push(self.comment_lines());
-        out.push(self.signature(&self.variables, &func_name).with_semicolon());
+        let mut sig = self.signature(&self.variables, &func_name);
+        if !self.elements.is_empty() {
+            sig.push_str(&format!(" /* elements: {} */", self.elements_summary()));
+        }
+        out.push(sig.with_semicolon());
 
         out.join("\n")
     }
@@ -23,6 +27,9 @@ impl Message {
     }
 
     pub fn implementations(&self, output_mode: &OutputMode) -> String {
+        if !self.elements.is_empty() {
+            return self.element_impl();
+        }
         let func_name = self.id.func_name();
         let mut out = String::new();
 
@@ -119,6 +126,176 @@ impl Message {
             .collect::<Vec<_>>()
             .join("")
     }
+
+    /// A short, human-readable summary of the `(Element)` layout. Used so that
+    /// cross-locale signature-mismatch warnings reflect element order.
+    fn elements_summary(&self) -> String {
+        let parts = self
+            .elements
+            .iter()
+            .map(|m| match m.kind {
+                ElementKind::Variable => format!("${}", m.name),
+                ElementKind::Term => format!("-{}", m.name),
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("[{parts}]")
+    }
+
+    /// The ordered struct fields for a structured (element) message: a text
+    /// slot, then each element slot, ending with a trailing text slot — always
+    /// `2 * elements + 1` fields.
+    fn element_fields(&self) -> Vec<Field> {
+        let mut fields: Vec<Field> = Vec::new();
+        for (i, marker) in self.elements.iter().enumerate() {
+            fields.push(Field {
+                name: format!("s{i}"),
+                kind: FieldKind::Text,
+            });
+            let kind = match marker.kind {
+                ElementKind::Variable => FieldKind::Gap,
+                ElementKind::Term => FieldKind::Term,
+            };
+            fields.push(Field {
+                name: marker.name.rust_id(),
+                kind,
+            });
+        }
+        fields.push(Field {
+            name: format!("s{}", self.elements.len()),
+            kind: FieldKind::Text,
+        });
+        dedup_field_names(&mut fields);
+        fields
+    }
+
+    /// The module-level `struct` + `Display` impl for a structured message.
+    /// Returns `None` for ordinary (non-element) messages.
+    pub fn element_struct(&self) -> Option<String> {
+        if self.elements.is_empty() {
+            return None;
+        }
+        let struct_name = self.id.message.rust_var_name();
+        let fields = self.element_fields();
+
+        let field_defs = fields
+            .iter()
+            .map(|f| {
+                let (ty, doc) = match f.kind {
+                    FieldKind::Text => ("String", "    /// A resolved run of translated text."),
+                    FieldKind::Gap => (
+                        "ElementGap",
+                        "    /// Element slot: the app injects its own UI element here.",
+                    ),
+                    FieldKind::Term => (
+                        "String",
+                        "    /// Resolved text of an `(Element)` term; wrap it in the app.",
+                    ),
+                };
+                format!("{doc}\n    pub {}: {ty},", f.name)
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let display_args = fields
+            .iter()
+            .filter(|f| f.kind != FieldKind::Gap)
+            .map(|f| format!("self.{}", f.name))
+            .collect::<Vec<_>>();
+        let display_fmt = "{}".repeat(display_args.len());
+        let display_args = display_args.join(", ");
+
+        Some(format!(
+            r##"/// Structured output for {id}.
+///
+/// Render the fields in declaration order. To keep bidirectional text correct,
+/// wrap each field — and each element the app injects — in an isolated bidi run
+/// (an HTML `<bdi>`, or `unicode-bidi: isolate`), with the container set to the
+/// locale's base direction.
+#[derive(Debug, Clone, PartialEq)]
+pub struct {struct_name} {{
+{field_defs}
+}}
+
+impl ::core::fmt::Display for {struct_name} {{
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {{
+        write!(f, "{display_fmt}", {display_args})
+    }}
+}}"##,
+            id = self.id,
+        ))
+    }
+
+    /// The `impl L10nLanguage` accessor for a structured message: resolves the
+    /// segments and builds the generated struct.
+    fn element_impl(&self) -> String {
+        let func_name = self.id.func_name();
+        let struct_name = self.id.message.rust_var_name();
+        let fields = self.element_fields();
+        let seg_count = fields.len();
+
+        let signature = if self.variables.is_empty() {
+            format!("    pub fn {func_name}(&self) -> {struct_name}")
+        } else {
+            let ArgInfo { generic, arg } = args_declaration(&self.variables);
+            let lt = lifetime(&self.variables);
+            format!("    pub fn {func_name}<{lt}{generic}>(&self, {arg}) -> {struct_name}")
+        };
+
+        let args_setup = if self.variables.is_empty() {
+            String::new()
+        } else {
+            format!(
+                "        let mut args = FluentArgs::new();\n{}\n",
+                args_impl(&self.variables)
+            )
+        };
+        let args_expr = if self.variables.is_empty() {
+            "None"
+        } else {
+            "Some(args)"
+        };
+
+        let vars_arr = quoted_element_names(&self.elements, ElementKind::Variable);
+        let terms_arr = quoted_element_names(&self.elements, ElementKind::Term);
+
+        let destructure = fields
+            .iter()
+            .enumerate()
+            .map(|(i, f)| match f.kind {
+                FieldKind::Gap => "_".to_string(),
+                _ => format!("seg{i}"),
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        let inits = fields
+            .iter()
+            .enumerate()
+            .map(|(i, f)| match f.kind {
+                FieldKind::Gap => format!("            {}: ElementGap,", f.name),
+                _ => format!("            {}: seg{i}.into_text(),", f.name),
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        format!(
+            r##"{comment}{signature} {{
+{args_setup}        let segments: [Segment; {seg_count}] = self
+            .0
+            .msg_segments("{msg_id}", &[{vars_arr}], &[{terms_arr}], {args_expr})
+            .unwrap()
+            .try_into()
+            .unwrap();
+        let [{destructure}] = segments;
+        {struct_name} {{
+{inits}
+        }}
+    }}"##,
+            comment = self.comment_lines(),
+            msg_id = self.id.message,
+        )
+    }
 }
 
 fn lifetime(vars: &[Variable]) -> &'static str {
@@ -183,4 +360,47 @@ impl ArgInfo {
         let arg = format!("{}: F{num}", var.id.rust_id());
         Some(Self { generic, arg })
     }
+}
+
+/// A field of a generated structured-message struct.
+struct Field {
+    name: String,
+    kind: FieldKind,
+}
+
+#[derive(PartialEq)]
+enum FieldKind {
+    /// A resolved text slot (`s0`, `s1`, …).
+    Text,
+    /// A variable `(Element)` — a positional gap.
+    Gap,
+    /// A term `(Element)` — resolved translatable text.
+    Term,
+}
+
+/// Ensure every generated struct field name is unique by suffixing repeats
+/// (e.g. the same element used twice, or an element named `s0`).
+fn dedup_field_names(fields: &mut [Field]) {
+    let mut seen: Vec<String> = Vec::new();
+    for field in fields.iter_mut() {
+        if seen.contains(&field.name) {
+            let base = field.name.clone();
+            let mut n = 2;
+            while seen.contains(&field.name) {
+                field.name = format!("{base}_{n}");
+                n += 1;
+            }
+        }
+        seen.push(field.name.clone());
+    }
+}
+
+/// Comma-separated, quoted names of the element markers of the given kind.
+fn quoted_element_names(elements: &[ElementMarker], kind: ElementKind) -> String {
+    elements
+        .iter()
+        .filter(|m| m.kind == kind)
+        .map(|m| format!("\"{}\"", m.name))
+        .collect::<Vec<_>>()
+        .join(", ")
 }

--- a/src/build/gen/mod.rs
+++ b/src/build/gen/mod.rs
@@ -212,6 +212,23 @@ static ALL_LANGS: [L10n; {}] = [
     });
     replacements.push(("<<message implementations>>", impls));
 
+    // ///////////////////////////
+    // Module-level `struct` + `Display` definitions for structured (element)
+    // messages. Empty when no message uses `(Element)` markers, in which case
+    // `do_replace` drops the placeholder line.
+    let structs = messages
+        .iter()
+        .filter_map(|msg| msg.element_struct())
+        .collect::<Vec<_>>();
+    let structs = if structs.is_empty() {
+        // Drops the placeholder line entirely; output is unchanged for
+        // projects without any structured (element) messages.
+        String::new()
+    } else {
+        format!("\n{}", structs.join("\n\n"))
+    };
+    replacements.push(("<<message structs>>", structs));
+
     let mut base = do_replace(include_str!("template.rs"), replacements);
     base.push('\n');
 
@@ -232,8 +249,10 @@ fn do_replace(base: &str, replacements: Vec<(&str, String)>) -> String {
             }
             for (placeholder, replacement) in &replacements {
                 if line.contains(placeholder) {
+                    // An empty replacement drops the placeholder line; this is
+                    // expected for optional sections (e.g. no element structs,
+                    // or feature-gated code).
                     return if replacement.is_empty() {
-                        eprintln!("Empty replacement for placeholder: {}", placeholder);
                         None
                     } else {
                         Some(replacement.to_string())

--- a/src/build/gen/template.rs
+++ b/src/build/gen/template.rs
@@ -84,3 +84,4 @@ impl L10nLanguage {
 
     // <<message implementations>>
 }
+// <<message structs>>

--- a/src/build/typed/mod.rs
+++ b/src/build/typed/mod.rs
@@ -10,6 +10,9 @@ pub struct Message {
     pub id: Id,
     pub comment: Vec<String>,
     pub variables: Vec<Variable>,
+    /// The `(Element)`-annotated split points, in the order they appear in the
+    /// message pattern. Empty for ordinary (non-structured) messages.
+    pub elements: Vec<ElementMarker>,
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
@@ -72,4 +75,21 @@ pub enum VarType {
     Any,
     String,
     Number,
+}
+
+/// An `(Element)`-annotated split point in a message pattern.
+///
+/// A variable element (`$icon`) is a pure positional gap that the consuming
+/// app fills with its own UI element. A term element (`-privacy-link`) carries
+/// translatable text that the app wraps.
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub struct ElementMarker {
+    pub name: String,
+    pub kind: ElementKind,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
+pub enum ElementKind {
+    Variable,
+    Term,
 }

--- a/src/build/typed/parse_ast.rs
+++ b/src/build/typed/parse_ast.rs
@@ -14,6 +14,9 @@ impl Message {
             let mut variables = find_variable_references(value);
             let tic = TypeInComment::parse(&comment);
             tic.update_types(&mut variables);
+            let elements = find_elements(value, tic.element_vars(), tic.element_terms());
+            // Element variables are positional gaps, not function arguments.
+            variables.retain(|v| !tic.element_vars().contains(&v.id));
             let id = Id {
                 message: message.id.name.to_owned(),
                 attribute: None,
@@ -22,6 +25,7 @@ impl Message {
                 id,
                 comment,
                 variables,
+                elements,
             });
         }
         for attribute in find_attributes(&message.attributes) {
@@ -34,6 +38,7 @@ impl Message {
                 id,
                 comment: vec![],
                 variables,
+                elements: vec![],
             });
         }
         found
@@ -87,6 +92,45 @@ pub fn find_variable_references(pattern: &ast::Pattern<&str>) -> Vec<Variable> {
 
 pub fn find_attributes<'ast>(attributes: &'ast [ast::Attribute<&'ast str>]) -> Vec<Attribute> {
     attributes.iter().map(Attribute::parse).collect()
+}
+
+/// Walk the pattern and collect the `(Element)`-annotated placeables, in order.
+///
+/// A placeable is a marker iff its variable/term name was annotated `(Element)`
+/// in the message comment. Everything else (text, ordinary variables, selects,
+/// un-annotated term references) is ordinary content.
+pub fn find_elements(
+    pattern: &ast::Pattern<&str>,
+    element_vars: &[String],
+    element_terms: &[String],
+) -> Vec<ElementMarker> {
+    let mut elements = vec![];
+
+    for element in &pattern.elements {
+        let ast::PatternElement::Placeable { expression } = element else {
+            continue;
+        };
+        match expression {
+            ast::Expression::Inline(ast::InlineExpression::VariableReference { id })
+                if element_vars.iter().any(|v| v == id.name) =>
+            {
+                elements.push(ElementMarker {
+                    name: id.name.to_owned(),
+                    kind: ElementKind::Variable,
+                });
+            }
+            ast::Expression::Inline(ast::InlineExpression::TermReference { id, .. })
+                if element_terms.iter().any(|t| t == id.name) =>
+            {
+                elements.push(ElementMarker {
+                    name: id.name.to_owned(),
+                    kind: ElementKind::Term,
+                });
+            }
+            _ => {}
+        }
+    }
+    elements
 }
 
 trait AstVariantExt {

--- a/src/build/typed/type_in_comment.rs
+++ b/src/build/typed/type_in_comment.rs
@@ -1,25 +1,31 @@
 use super::{VarType, Variable};
 
+/// Type and `(Element)` annotations extracted from a message comment.
+///
+/// `(String)` / `(Number)` apply to `$variable`s; `(Element)` applies to either
+/// a `$variable` (a positional gap) or a `-term` (translatable wrapped text).
 #[derive(Debug, PartialEq, Default)]
 pub struct TypeInComment {
     string: Vec<String>,
     number: Vec<String>,
+    element_vars: Vec<String>,
+    element_terms: Vec<String>,
 }
 
 impl TypeInComment {
     pub fn parse(comment: &[String]) -> Self {
-        let mut string = vec![];
-        let mut number = vec![];
+        let mut tic = Self::default();
 
         for line in comment {
             match parse_line(line) {
-                Found::String(s) => string.push(s.to_owned()),
-                Found::Number(n) => number.push(n.to_owned()),
+                Found::String(s) => tic.string.push(s.to_owned()),
+                Found::Number(n) => tic.number.push(n.to_owned()),
+                Found::ElementVar(v) => tic.element_vars.push(v.to_owned()),
+                Found::ElementTerm(t) => tic.element_terms.push(t.to_owned()),
                 Found::Nothing => {}
             }
         }
-
-        Self { string, number }
+        tic
     }
 
     pub fn update_types(&self, variables: &mut Vec<Variable>) {
@@ -31,11 +37,23 @@ impl TypeInComment {
             }
         }
     }
+
+    /// Names of `$variable`s annotated `(Element)`.
+    pub fn element_vars(&self) -> &[String] {
+        &self.element_vars
+    }
+
+    /// Names of `-term`s annotated `(Element)`.
+    pub fn element_terms(&self) -> &[String] {
+        &self.element_terms
+    }
 }
 
 enum Found<'a> {
     String(&'a str),
     Number(&'a str),
+    ElementVar(&'a str),
+    ElementTerm(&'a str),
     Nothing,
 }
 
@@ -45,17 +63,25 @@ fn parse_line(line: &str) -> Found<'_> {
     };
 
     let id = id.trim();
+    let rest = rest.trim();
 
-    if !id.starts_with('$') {
+    let is_term = id.starts_with('-');
+    let is_var = id.starts_with('$');
+    if !is_term && !is_var {
         return Found::Nothing;
     }
-    let id = &id[1..];
+    let name = &id[1..];
 
-    let rest = rest.trim();
-    if rest.starts_with("(Number)") {
-        Found::Number(id)
-    } else if rest.starts_with("(String)") {
-        Found::String(id)
+    if rest.starts_with("(Element)") {
+        if is_term {
+            Found::ElementTerm(name)
+        } else {
+            Found::ElementVar(name)
+        }
+    } else if is_var && rest.starts_with("(Number)") {
+        Found::Number(name)
+    } else if is_var && rest.starts_with("(String)") {
+        Found::String(name)
     } else {
         Found::Nothing
     }
@@ -71,6 +97,20 @@ fn test_number() {
         TypeInComment {
             string: vec![],
             number: vec!["duration".to_string()],
+            element_vars: vec![],
+            element_terms: vec![],
         }
     );
+}
+
+#[test]
+fn test_element_var_and_term() {
+    let lines = [
+        "$icon (Element) - A UI element injected by the app.".to_owned(),
+        "-privacy-link (Element) - Translatable text wrapped by the app.".to_owned(),
+    ];
+
+    let tic = TypeInComment::parse(&lines);
+    assert_eq!(tic.element_vars(), ["icon".to_string()]);
+    assert_eq!(tic.element_terms(), ["privacy-link".to_string()]);
 }

--- a/src/build/validations.rs
+++ b/src/build/validations.rs
@@ -2,8 +2,13 @@ use std::collections::{HashMap, HashSet};
 
 use crate::{
     build::LangBundle,
-    build::typed::{Id, Variable},
+    build::typed::{ElementMarker, Id, Variable},
 };
+
+/// A message's cross-locale signature: its argument variables together with its
+/// ordered `(Element)` layout. Two locales' messages are compatible only when
+/// both match.
+type Signature<'a> = (&'a [Variable], &'a [ElementMarker]);
 
 #[derive(Debug)]
 pub struct Analyzed {
@@ -50,13 +55,13 @@ fn signature_mismatches(
     (messages, mismatched_ids)
 }
 
-fn signatures_for_id<'a>(id: &Id, langs: &'a [LangBundle]) -> HashMap<&'a [Variable], Vec<String>> {
-    let mut signatures: HashMap<&[Variable], Vec<String>> = HashMap::new();
+fn signatures_for_id<'a>(id: &Id, langs: &'a [LangBundle]) -> HashMap<Signature<'a>, Vec<String>> {
+    let mut signatures: HashMap<Signature<'a>, Vec<String>> = HashMap::new();
     for lang in langs {
         for msg in &lang.messages {
             if &msg.id == id {
                 signatures
-                    .entry(&msg.variables)
+                    .entry((msg.variables.as_slice(), msg.elements.as_slice()))
                     .or_default()
                     .push(msg.trait_signature());
             }

--- a/src/l10n_bundle.rs
+++ b/src/l10n_bundle.rs
@@ -5,6 +5,8 @@ use fluent_syntax::ast::{
 };
 use unic_langid::LanguageIdentifier;
 
+use crate::structured::Segment;
+
 pub struct L10nBundle {
     lang: String,
     bundle: FluentBundle<FluentResource>,
@@ -70,6 +72,72 @@ impl L10nBundle {
         to_owned_pattern(pattern)
     }
 
+    /// Resolve `id` into ordered [`Segment`]s, split at the `(Element)` markers
+    /// named in `element_vars` / `element_terms`.
+    ///
+    /// The result alternates `Text, Element, Text, …` and always holds
+    /// `2 * markers + 1` entries (text segments may be empty). Generated
+    /// structured-message accessors map this directly into a typed struct.
+    pub fn msg_segments(
+        &self,
+        id: &str,
+        element_vars: &[&str],
+        element_terms: &[&str],
+        args: Option<FluentArgs>,
+    ) -> Result<Vec<Segment>, String> {
+        let pattern = self.try_get_pattern(id, None)?;
+        let args = args.as_ref();
+
+        let mut segments = Vec::new();
+        let mut current: Vec<PatternElement<&str>> = Vec::new();
+
+        for element in &pattern.elements {
+            match element_marker(element, element_vars, element_terms) {
+                Some(Marker::Variable) => {
+                    segments.push(Segment::Text(self.resolve_segment(id, &current, args)?));
+                    current.clear();
+                    segments.push(Segment::Gap);
+                }
+                Some(Marker::Term) => {
+                    segments.push(Segment::Text(self.resolve_segment(id, &current, args)?));
+                    current.clear();
+                    let text = self.resolve_segment(id, std::slice::from_ref(element), args)?;
+                    segments.push(Segment::Term(text));
+                }
+                None => current.push(element.clone()),
+            }
+        }
+        segments.push(Segment::Text(self.resolve_segment(id, &current, args)?));
+        Ok(segments)
+    }
+
+    /// Resolve a slice of pattern elements as their own sub-pattern.
+    ///
+    /// A leading empty `TextElement` is prepended so the sub-pattern always has
+    /// more than one element. Fluent only wraps a placeable in bidi isolation
+    /// marks when its pattern has `len > 1`, so this padding makes a split
+    /// segment resolve byte-identically to the same span of the whole,
+    /// un-split message.
+    fn resolve_segment(
+        &self,
+        id: &str,
+        elements: &[PatternElement<&str>],
+        args: Option<&FluentArgs>,
+    ) -> Result<String, String> {
+        let mut padded = Vec::with_capacity(elements.len() + 1);
+        padded.push(PatternElement::TextElement { value: "" });
+        padded.extend(elements.iter().cloned());
+        let sub = Pattern { elements: padded };
+
+        let mut errors = vec![];
+        let value = self.bundle.format_pattern(&sub, args, &mut errors);
+        if errors.is_empty() {
+            Ok(value.to_string())
+        } else {
+            Err(format!("Invalid format for message '{id}': {errors:?}"))
+        }
+    }
+
     fn try_get_pattern(
         &self,
         msg_id: &str,
@@ -115,6 +183,35 @@ impl L10nBundle {
         } else {
             Ok(value.to_string())
         }
+    }
+}
+
+/// Which kind of `(Element)` marker a pattern element is, if any.
+enum Marker {
+    Variable,
+    Term,
+}
+
+fn element_marker(
+    element: &PatternElement<&str>,
+    element_vars: &[&str],
+    element_terms: &[&str],
+) -> Option<Marker> {
+    let PatternElement::Placeable { expression } = element else {
+        return None;
+    };
+    match expression {
+        Expression::Inline(InlineExpression::VariableReference { id })
+            if element_vars.contains(&id.name) =>
+        {
+            Some(Marker::Variable)
+        }
+        Expression::Inline(InlineExpression::TermReference { id, .. })
+            if element_terms.contains(&id.name) =>
+        {
+            Some(Marker::Term)
+        }
+        _ => None,
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 mod build;
 mod l10n_bundle;
 mod l10n_language_vec;
+mod structured;
 
 #[cfg(all(test, feature = "build"))]
 mod tests;
@@ -16,6 +17,7 @@ pub use build::{
 pub mod prelude {
     pub use crate::l10n_bundle::L10nBundle;
     pub use crate::l10n_language_vec::L10nLanguageVec;
+    pub use crate::structured::{ElementGap, Segment};
     pub use fluent_bundle::{FluentArgs, FluentValue, types::FluentNumber};
     pub use fluent_syntax::ast::{Pattern, PatternElement};
     #[cfg(feature = "langneg")]

--- a/src/structured.rs
+++ b/src/structured.rs
@@ -1,0 +1,39 @@
+//! Types for structured (`(Element)`-annotated) message output.
+//!
+//! A message that uses `(Element)` markers is generated as a struct whose
+//! fields are the resolved text segments and the element slots, in render
+//! order. The generated accessor builds that struct from the [`Segment`]s
+//! returned by [`L10nBundle::msg_segments`](crate::prelude::L10nBundle::msg_segments).
+
+/// One resolved piece of a structured message.
+///
+/// [`L10nBundle::msg_segments`](crate::prelude::L10nBundle::msg_segments)
+/// returns these in render order, alternating `Text, Element, Text, …`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Segment {
+    /// A resolved run of translated text.
+    Text(String),
+    /// A variable `(Element)` — a positional gap the app fills with its own
+    /// UI element.
+    Gap,
+    /// A term `(Element)` — resolved translatable text the app wraps.
+    Term(String),
+}
+
+impl Segment {
+    /// The resolved text of this segment. A [`Segment::Gap`] carries no text
+    /// and yields an empty string.
+    pub fn into_text(self) -> String {
+        match self {
+            Segment::Text(s) | Segment::Term(s) => s,
+            Segment::Gap => String::new(),
+        }
+    }
+}
+
+/// A variable `(Element)` slot in a generated structured-message struct.
+///
+/// It carries no data: the field exists only to mark — in render order — the
+/// position where the consuming app injects its own UI element.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Hash)]
+pub struct ElementGap;

--- a/src/tests/ast/attrib_only.rs
+++ b/src/tests/ast/attrib_only.rs
@@ -80,6 +80,7 @@ fn typed() {
                 id: "userName".to_string(),
                 typ: VarType::Any
             }],
+            elements: vec![],
         }
     );
 }

--- a/src/tests/ast/mod.rs
+++ b/src/tests/ast/mod.rs
@@ -1,4 +1,5 @@
 mod attrib_only;
+mod msg_element;
 mod msg_number;
 mod msg_select;
 mod msg_select_num;

--- a/src/tests/ast/msg_element.rs
+++ b/src/tests/ast/msg_element.rs
@@ -1,0 +1,63 @@
+use super::assert_gen;
+use crate::build::typed::*;
+use crate::tests::ast::AstResourceExt;
+use fluent_syntax::parser;
+
+const FTL: &str = r#"
+# $num (Number) - How many.
+# $provider (String) - The calendar provider.
+# $icon (Element) - A UI element injected by the app.
+# -privacy-link (Element) - Translatable text the app wraps.
+calendar-sync-description =
+    Sync calendar { $num } using { $provider ->
+        [google] Google Calendar
+       *[other] external calendar
+    } { $icon } feed, see { -privacy-link } for more information.
+-privacy-link = our privacy policy
+"#;
+
+#[test]
+fn typed() {
+    let resource = parser::parse(FTL).expect("Failed to parse an FTL resource.");
+    let message = resource.first_message();
+
+    println!("{message:#?}");
+    assert_eq!(
+        message,
+        Message {
+            id: Id::new_msg("calendar-sync-description"),
+            comment: vec![
+                "$num (Number) - How many.".to_string(),
+                "$provider (String) - The calendar provider.".to_string(),
+                "$icon (Element) - A UI element injected by the app.".to_string(),
+                "-privacy-link (Element) - Translatable text the app wraps.".to_string(),
+            ],
+            // Element variables ($icon) are positional gaps, not arguments.
+            variables: vec![
+                Variable {
+                    id: "num".to_string(),
+                    typ: VarType::Number,
+                },
+                Variable {
+                    id: "provider".to_string(),
+                    typ: VarType::String,
+                },
+            ],
+            elements: vec![
+                ElementMarker {
+                    name: "icon".to_string(),
+                    kind: ElementKind::Variable,
+                },
+                ElementMarker {
+                    name: "privacy-link".to_string(),
+                    kind: ElementKind::Term,
+                },
+            ],
+        }
+    );
+}
+
+#[test]
+fn typed_gen() {
+    assert_gen(module_path!(), "test", FTL);
+}

--- a/src/tests/ast/msg_number.rs
+++ b/src/tests/ast/msg_number.rs
@@ -77,6 +77,7 @@ fn typed() {
                 id: "duration".to_string(),
                 typ: VarType::Number,
             }],
+            elements: vec![],
         }
     );
 }

--- a/src/tests/ast/msg_select.rs
+++ b/src/tests/ast/msg_select.rs
@@ -88,6 +88,7 @@ fn typed() {
                 id: "var".to_string(),
                 typ: VarType::Any,
             }],
+            elements: vec![],
         }
     );
 }

--- a/src/tests/ast/msg_select_num.rs
+++ b/src/tests/ast/msg_select_num.rs
@@ -101,6 +101,7 @@ fn typed() {
                 id: "num".to_string(),
                 typ: VarType::Number,
             }],
+            elements: vec![],
         }
     );
 }

--- a/src/tests/ast/msg_string.rs
+++ b/src/tests/ast/msg_string.rs
@@ -72,6 +72,7 @@ fn typed() {
                 id: "name".to_string(),
                 typ: VarType::String,
             }],
+            elements: vec![],
         }
     );
 }

--- a/src/tests/ast/msg_text.rs
+++ b/src/tests/ast/msg_text.rs
@@ -60,6 +60,7 @@ fn typed() {
             id: Id::new_msg("hello-world"),
             comment: vec![],
             variables: vec![],
+            elements: vec![],
         }
     );
 }

--- a/src/tests/ast/msg_with_attrib.rs
+++ b/src/tests/ast/msg_with_attrib.rs
@@ -85,6 +85,7 @@ fn typed() {
             comment: vec!["This is a message comment".to_string()],
             id: Id::new_msg("hello"),
             variables: vec![],
+            elements: vec![],
         }
     );
     println!("{:#?}", attr);
@@ -97,6 +98,7 @@ fn typed() {
                 id: "userName".to_string(),
                 typ: VarType::Any
             }],
+            elements: vec![],
         }
     );
 }

--- a/src/tests/ast/msg_with_var.rs
+++ b/src/tests/ast/msg_with_var.rs
@@ -68,6 +68,7 @@ fn typed() {
                 id: "first-name".to_string(),
                 typ: VarType::Any
             }],
+            elements: vec![],
         }
     );
 }

--- a/src/tests/ast/res_msg_text.rs
+++ b/src/tests/ast/res_msg_text.rs
@@ -43,6 +43,7 @@ fn typed() {
             id: Id::new_msg("hello-world"),
             comment: vec![],
             variables: vec![],
+            elements: vec![],
         }
     );
 }

--- a/src/tests/gen/mod.rs
+++ b/src/tests/gen/mod.rs
@@ -3,6 +3,7 @@
 #![allow(unused, clippy::derivable_impls)]
 mod attrib_only_gen;
 mod complex_gen;
+mod msg_element_gen;
 mod msg_number_gen;
 mod msg_string_gen;
 mod msg_text_both_gen;

--- a/src/tests/gen/msg_element_gen.ftl
+++ b/src/tests/gen/msg_element_gen.ftl
@@ -1,0 +1,11 @@
+
+# $num (Number) - How many.
+# $provider (String) - The calendar provider.
+# $icon (Element) - A UI element injected by the app.
+# -privacy-link (Element) - Translatable text the app wraps.
+calendar-sync-description =
+    Sync calendar { $num } using { $provider ->
+        [google] Google Calendar
+       *[other] external calendar
+    } { $icon } feed, see { -privacy-link } for more information.
+-privacy-link = our privacy policy

--- a/src/tests/gen/msg_element_gen.rs
+++ b/src/tests/gen/msg_element_gen.rs
@@ -1,0 +1,178 @@
+// This file is generated. Do not edit it manually.
+use crate::prelude::*;
+use std::{
+    fmt::Display,
+    ops::{Deref, Range},
+    slice::Iter,
+    str::FromStr,
+};
+
+static LANG_DATA: &[u8] = include_bytes!("msg_element_gen.ftl");
+
+static ALL_LANGS: [L10n; 1] = [
+    // languages as an array
+    L10n::En,
+];
+
+static EN: LanguageIdentifier = langid!("en");
+
+/// The languages that have translations available.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum L10n {
+    En,
+}
+
+impl Default for L10n {
+    fn default() -> Self {
+        Self::En
+    }
+}
+
+impl FromStr for L10n {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "en" => Ok(Self::En),
+            _ => Err(format!("Unknown language: {}", s)),
+        }
+    }
+}
+
+impl Deref for L10n {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::En => "en",
+        }
+    }
+}
+
+impl AsRef<LanguageIdentifier> for L10n {
+    fn as_ref(&self) -> &LanguageIdentifier {
+        match self {
+            Self::En => &EN,
+        }
+    }
+}
+
+impl AsRef<str> for L10n {
+    fn as_ref(&self) -> &str {
+        self
+    }
+}
+
+impl Display for L10n {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.deref())
+    }
+}
+
+impl L10n {
+    pub fn iter() -> Iter<'static, L10n> {
+        ALL_LANGS.iter()
+    }
+
+    /// Negotiate the best language to use based on the `Accept-Language` header.
+    ///
+    /// Falls back to the default language if none of the languages in the header are available.
+    pub fn langneg(accept_language: &str) -> L10n {
+        negotiate_languages(accept_language, &ALL_LANGS)
+    }
+
+    fn byte_range(&self) -> Range<usize> {
+        match self {
+            Self::En => 0..434,
+        }
+    }
+    /// Load a L10nLanguage from the embedded data.
+    pub fn load(&self) -> L10nLanguage {
+        let bytes = LANG_DATA[self.byte_range()].to_vec();
+        L10nLanguage::new(self, &bytes).unwrap()
+    }
+
+    /// Load all languages (L10nLanguage) from the embedded data.
+    pub fn load_all() -> L10nLanguageVec {
+        L10nLanguageVec::load(
+            LANG_DATA,
+            Self::iter().map(|lang| (lang, lang.byte_range())),
+        )
+        .unwrap()
+    }
+}
+
+/// A thin wrapper around the Fluent messages for one language.
+///
+/// It provides functions for each message that was found in
+/// all the languages at build time.
+pub struct L10nLanguage(L10nBundle);
+
+impl L10nLanguage {
+    /// Load the L10n resources for the given language. The language
+    /// has to be a valid LanguageIdentifier or otherwise
+    /// an error is returned.
+    ///
+    /// The bytes are expected to be the contents of a .ftl file
+    pub fn new(lang: impl AsRef<str>, bytes: &[u8]) -> Result<Self, String> {
+        Ok(Self(L10nBundle::new(lang, bytes)?))
+    }
+
+    /// $num (Number) - How many.
+    /// $provider (String) - The calendar provider.
+    /// $icon (Element) - A UI element injected by the app.
+    /// -privacy-link (Element) - Translatable text the app wraps.
+    pub fn calendar_sync_description<F0: Into<FluentNumber>, F1: AsRef<str>>(
+        &self,
+        num: F0,
+        provider: F1,
+    ) -> CalendarSyncDescription {
+        let mut args = FluentArgs::new();
+        args.set("num", num.into());
+        args.set("provider", provider.as_ref());
+        let segments: [Segment; 5] = self
+            .0
+            .msg_segments(
+                "calendar-sync-description",
+                &["icon"],
+                &["privacy-link"],
+                Some(args),
+            )
+            .unwrap()
+            .try_into()
+            .unwrap();
+        let [seg0, _, seg2, seg3, seg4] = segments;
+        CalendarSyncDescription {
+            s0: seg0.into_text(),
+            icon: ElementGap,
+            s1: seg2.into_text(),
+            privacy_link: seg3.into_text(),
+            s2: seg4.into_text(),
+        }
+    }
+}
+
+/// Structured output for message 'calendar-sync-description'.
+///
+/// Render the fields in declaration order. To keep bidirectional text correct,
+/// wrap each field — and each element the app injects — in an isolated bidi run
+/// (an HTML `<bdi>`, or `unicode-bidi: isolate`), with the container set to the
+/// locale's base direction.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CalendarSyncDescription {
+    /// A resolved run of translated text.
+    pub s0: String,
+    /// Element slot: the app injects its own UI element here.
+    pub icon: ElementGap,
+    /// A resolved run of translated text.
+    pub s1: String,
+    /// Resolved text of an `(Element)` term; wrap it in the app.
+    pub privacy_link: String,
+    /// A resolved run of translated text.
+    pub s2: String,
+}
+
+impl ::core::fmt::Display for CalendarSyncDescription {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        write!(f, "{}{}{}{}", self.s0, self.s1, self.privacy_link, self.s2)
+    }
+}

--- a/src/tests/runtime.rs
+++ b/src/tests/runtime.rs
@@ -3,7 +3,7 @@
 //! These exercise the actual message-formatting path end to end, including
 //! the bidi-isolation behavior that the generated accessors depend on.
 
-use crate::prelude::{FluentArgs, L10nBundle, L10nLanguageVec};
+use crate::prelude::{FluentArgs, L10nBundle, L10nLanguageVec, Segment};
 
 const FTL: &str = r#"
 greeting = Hello world
@@ -54,6 +54,75 @@ fn attribute_message() {
 fn unknown_message_is_an_error() {
     let bundle = L10nBundle::new("en", FTL.as_bytes()).unwrap();
     assert!(bundle.msg("does-not-exist", None).is_err());
+}
+
+const ELEMENT_FTL: &str = r#"
+calendar-sync-description =
+    Sync calendar { $num } using { $provider ->
+        [google] Google Calendar
+       *[other] external calendar
+    } { $icon } feed, see { -privacy-link } for more information.
+-privacy-link = our privacy policy
+edge = { $before }{ $count }{ $after }
+"#;
+
+#[test]
+fn msg_segments_splits_at_element_markers() {
+    let bundle = L10nBundle::new("en", ELEMENT_FTL.as_bytes()).unwrap();
+    let mut args = FluentArgs::new();
+    args.set("num", 2);
+    args.set("provider", "google");
+
+    let segments = bundle
+        .msg_segments(
+            "calendar-sync-description",
+            &["icon"],
+            &["privacy-link"],
+            Some(args),
+        )
+        .unwrap();
+
+    // Text segments resolve with selects evaluated and variables bidi-isolated;
+    // the variable element is a gap, the term element carries resolved text.
+    assert_eq!(
+        segments,
+        vec![
+            Segment::Text(
+                "Sync calendar \u{2068}2\u{2069} using \u{2068}Google Calendar\u{2069} "
+                    .to_string()
+            ),
+            Segment::Gap,
+            Segment::Text(" feed, see ".to_string()),
+            Segment::Term("our privacy policy".to_string()),
+            Segment::Text(" for more information.".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn msg_segments_pads_lone_placeable_for_bidi_isolation() {
+    // `$count` sits alone between two adjacent element markers. Fluent skips
+    // bidi isolation for a single-element pattern; the empty-TextElement
+    // padding in `resolve_segment` makes the lone placeable isolate exactly
+    // as it would in the whole, un-split message.
+    let bundle = L10nBundle::new("en", ELEMENT_FTL.as_bytes()).unwrap();
+    let mut args = FluentArgs::new();
+    args.set("count", 5);
+
+    let segments = bundle
+        .msg_segments("edge", &["before", "after"], &[], Some(args))
+        .unwrap();
+
+    assert_eq!(
+        segments,
+        vec![
+            Segment::Text(String::new()),
+            Segment::Gap,
+            Segment::Text("\u{2068}5\u{2069}".to_string()),
+            Segment::Gap,
+            Segment::Text(String::new()),
+        ]
+    );
 }
 
 #[test]

--- a/src/tests/snapshots/fluent_typed__tests__msg_element.snap
+++ b/src/tests/snapshots/fluent_typed__tests__msg_element.snap
@@ -1,0 +1,183 @@
+---
+source: src/tests/mod.rs
+assertion_line: 42
+expression: generated
+---
+// This file is generated. Do not edit it manually.
+use crate::prelude::*;
+use std::{
+    fmt::Display,
+    ops::{Deref, Range},
+    slice::Iter,
+    str::FromStr,
+};
+
+static LANG_DATA: &[u8] = include_bytes!("msg_element_gen.ftl");
+
+static ALL_LANGS: [L10n; 1] = [
+    // languages as an array
+    L10n::En,
+];
+
+static EN: LanguageIdentifier = langid!("en");
+
+/// The languages that have translations available.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum L10n {
+    En,
+}
+
+impl Default for L10n {
+    fn default() -> Self {
+        Self::En
+    }
+}
+
+impl FromStr for L10n {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "en" => Ok(Self::En),
+            _ => Err(format!("Unknown language: {}", s)),
+        }
+    }
+}
+
+impl Deref for L10n {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::En => "en",
+        }
+    }
+}
+
+impl AsRef<LanguageIdentifier> for L10n {
+    fn as_ref(&self) -> &LanguageIdentifier {
+        match self {
+            Self::En => &EN,
+        }
+    }
+}
+
+impl AsRef<str> for L10n {
+    fn as_ref(&self) -> &str {
+        self
+    }
+}
+
+impl Display for L10n {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.deref())
+    }
+}
+
+impl L10n {
+    pub fn iter() -> Iter<'static, L10n> {
+        ALL_LANGS.iter()
+    }
+
+    /// Negotiate the best language to use based on the `Accept-Language` header.
+    ///
+    /// Falls back to the default language if none of the languages in the header are available.
+    pub fn langneg(accept_language: &str) -> L10n {
+        negotiate_languages(accept_language, &ALL_LANGS)
+    }
+
+    fn byte_range(&self) -> Range<usize> {
+        match self {
+            Self::En => 0..434,
+        }
+    }
+    /// Load a L10nLanguage from the embedded data.
+    pub fn load(&self) -> L10nLanguage {
+        let bytes = LANG_DATA[self.byte_range()].to_vec();
+        L10nLanguage::new(self, &bytes).unwrap()
+    }
+
+    /// Load all languages (L10nLanguage) from the embedded data.
+    pub fn load_all() -> L10nLanguageVec {
+        L10nLanguageVec::load(
+            LANG_DATA,
+            Self::iter().map(|lang| (lang, lang.byte_range())),
+        )
+        .unwrap()
+    }
+}
+
+/// A thin wrapper around the Fluent messages for one language.
+///
+/// It provides functions for each message that was found in
+/// all the languages at build time.
+pub struct L10nLanguage(L10nBundle);
+
+impl L10nLanguage {
+    /// Load the L10n resources for the given language. The language
+    /// has to be a valid LanguageIdentifier or otherwise
+    /// an error is returned.
+    ///
+    /// The bytes are expected to be the contents of a .ftl file
+    pub fn new(lang: impl AsRef<str>, bytes: &[u8]) -> Result<Self, String> {
+        Ok(Self(L10nBundle::new(lang, bytes)?))
+    }
+
+    /// $num (Number) - How many.
+    /// $provider (String) - The calendar provider.
+    /// $icon (Element) - A UI element injected by the app.
+    /// -privacy-link (Element) - Translatable text the app wraps.
+    pub fn calendar_sync_description<F0: Into<FluentNumber>, F1: AsRef<str>>(
+        &self,
+        num: F0,
+        provider: F1,
+    ) -> CalendarSyncDescription {
+        let mut args = FluentArgs::new();
+        args.set("num", num.into());
+        args.set("provider", provider.as_ref());
+        let segments: [Segment; 5] = self
+            .0
+            .msg_segments(
+                "calendar-sync-description",
+                &["icon"],
+                &["privacy-link"],
+                Some(args),
+            )
+            .unwrap()
+            .try_into()
+            .unwrap();
+        let [seg0, _, seg2, seg3, seg4] = segments;
+        CalendarSyncDescription {
+            s0: seg0.into_text(),
+            icon: ElementGap,
+            s1: seg2.into_text(),
+            privacy_link: seg3.into_text(),
+            s2: seg4.into_text(),
+        }
+    }
+}
+
+/// Structured output for message 'calendar-sync-description'.
+///
+/// Render the fields in declaration order. To keep bidirectional text correct,
+/// wrap each field — and each element the app injects — in an isolated bidi run
+/// (an HTML `<bdi>`, or `unicode-bidi: isolate`), with the container set to the
+/// locale's base direction.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CalendarSyncDescription {
+    /// A resolved run of translated text.
+    pub s0: String,
+    /// Element slot: the app injects its own UI element here.
+    pub icon: ElementGap,
+    /// A resolved run of translated text.
+    pub s1: String,
+    /// Resolved text of an `(Element)` term; wrap it in the app.
+    pub privacy_link: String,
+    /// A resolved run of translated text.
+    pub s2: String,
+}
+
+impl ::core::fmt::Display for CalendarSyncDescription {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        write!(f, "{}{}{}{}", self.s0, self.s1, self.privacy_link, self.s2)
+    }
+}


### PR DESCRIPTION
## Context

[FE-909](https://linear.app/leave-dates/issue/FE-909) — some translations embed UI elements mid-sentence by putting placeholder tokens in the translated string, then splitting that string UI-side and injecting elements. The token isn't valid Fluent syntax (translation tooling won't recognize it) and the split-and-inject runs on every render.

This is the **library half**: `fluent-typed` now emits structured output directly. The leave-dates app's rendering-path migration is separate.

## What this adds

Annotate a variable or term with `(Element)` in the message comment:

```ftl
# $count (Number) - How many unread.
# $icon (Element) - An icon injected by the app.
# -privacy-link (Element) - Link text the app wraps.
notice = { $icon } You have { $count } unread, see { -privacy-link }.
-privacy-link = our privacy policy
```

fluent-typed generates a per-message struct of resolved text segments split at the markers, plus a struct-returning accessor and a `Display` impl:

```rust
pub struct Notice { s0: String, icon: ElementGap, s1: String, privacy_link: String, s2: String }
pub fn notice(&self, count: F0) -> Notice  // $icon / -privacy-link are not parameters
```

- A variable `(Element)` is a pure positional gap the app fills; a term `(Element)` carries translatable text the app wraps.
- Selects and ordinary variables inside each segment are fully resolved — the app never re-implements plural logic.

## How it works

Segments are produced by splitting the message's `Vec<PatternElement>` at the markers and calling the public `format_pattern` on each sub-pattern (no marker injection, no string splitting). Each sub-pattern is padded with an empty `TextElement` so `format_pattern` always sees `len > 1` and applies Fluent's native bidi (FSI/PDI) isolation **exactly as in the whole, un-split message** — verified by a runtime test where a lone variable between two markers resolves to `⁨5⁩`.

Cross-segment bidi (between segments and app-injected elements) is render-time; it's documented as a `<bdi>` contract in the generated struct's doc comments.

New public surface: `L10nBundle::msg_segments()` and the `Segment` / `ElementGap` prelude types. Element-layout consistency is folded into the existing cross-locale signature check.

## Verification

- `cargo build` (default + `--no-default-features`), `cargo clippy --all-targets`, `cargo fmt --check` — all clean
- `cargo test` — 59 lib tests + playground test pass (new: AST parse, gen snapshot, two `msg_segments` runtime tests)
- Built `playground/example1` with an element-message end-to-end (external `fluent_typed::prelude` path), then reverted

## Note

Like `(String)`/`(Number)`, the `(Element)` annotation must be present and consistent across all locales. If a locale's comment is missing or element order differs, the cross-locale signature check catches it, prints a `cargo::warning`, and skips the message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)