### PR TITLE
Detect NUMBER() arguments and select-variant variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@
   set with the (no longer deprecated) `BuildOptions::with_prefix()`.
 
 ### Fixed
+- `NUMBER()` calls now trigger number type deduction as documented. A variable
+  used inside `NUMBER(...)`, in a function-reference selector, or only inside a
+  select variant's body was not detected at all, so the generated accessor
+  silently omitted that parameter.
+- FTL builtins (`NUMBER`, …) are now registered on the runtime `L10nBundle`.
+  Previously a message using `{ NUMBER($x) }` failed to format, which made the
+  generated accessor panic when called.
 - An empty locales folder now returns the new `BuildError::NoLocaleFolders`
   variant instead of panicking.
 

--- a/src/build/typed/mod.rs
+++ b/src/build/typed/mod.rs
@@ -70,7 +70,7 @@ pub struct Variable {
     pub typ: VarType,
 }
 
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum VarType {
     Any,
     String,

--- a/src/build/typed/parse_ast.rs
+++ b/src/build/typed/parse_ast.rs
@@ -55,39 +55,108 @@ impl Attribute {
     }
 }
 
+/// Collect every `$variable` referenced anywhere in a message pattern, in the
+/// order they first appear, inferring `Number` where the syntax demands it.
+///
+/// The walk descends into selects (the selector *and* every variant body),
+/// function- and term-call arguments, and nested placeables — anywhere a
+/// variable can hide. A variable is typed `Number` when it is the value
+/// formatted by a `NUMBER()` call or the selector of an all-numeric select;
+/// otherwise it is `Any` (a `(String)`/`(Number)` comment annotation may still
+/// refine it later — see `TypeInComment::update_types`).
 pub fn find_variable_references(pattern: &ast::Pattern<&str>) -> Vec<Variable> {
-    let mut variables = vec![];
+    let mut collector = VarCollector::default();
+    collector.visit_pattern(pattern);
+    collector.variables
+}
 
-    for element in &pattern.elements {
-        match element {
-            ast::PatternElement::Placeable { expression } => match expression {
-                ast::Expression::Inline(ast::InlineExpression::VariableReference { id }) => {
-                    variables.push(Variable {
-                        id: id.name.to_owned(),
-                        typ: VarType::Any,
-                    });
+#[derive(Default)]
+struct VarCollector {
+    variables: Vec<Variable>,
+}
+
+impl VarCollector {
+    /// Record a reference to `$id`. The same variable may be referenced many
+    /// times; it is collected once and keeps its most specific type — once
+    /// known to be a `Number` it is never downgraded back to `Any`.
+    fn add(&mut self, id: &str, typ: VarType) {
+        match self.variables.iter_mut().find(|v| v.id == id) {
+            Some(existing) => {
+                if existing.typ == VarType::Any {
+                    existing.typ = typ;
                 }
-                ast::Expression::Select {
-                    selector: ast::InlineExpression::VariableReference { id },
-                    variants,
-                } => {
-                    let is_num = variants.iter().all(|v| v.is_number());
-                    let typ = if is_num {
-                        VarType::Number
-                    } else {
-                        VarType::Any
-                    };
-                    variables.push(Variable {
-                        id: id.name.to_owned(),
-                        typ,
-                    });
-                }
-                _ => {}
-            },
-            ast::PatternElement::TextElement { value: _ } => {}
+            }
+            None => self.variables.push(Variable {
+                id: id.to_owned(),
+                typ,
+            }),
         }
     }
-    variables
+
+    fn visit_pattern(&mut self, pattern: &ast::Pattern<&str>) {
+        for element in &pattern.elements {
+            if let ast::PatternElement::Placeable { expression } = element {
+                self.visit_expression(expression);
+            }
+        }
+    }
+
+    fn visit_expression(&mut self, expression: &ast::Expression<&str>) {
+        match expression {
+            ast::Expression::Inline(inline) => self.visit_inline(inline, VarType::Any),
+            ast::Expression::Select { selector, variants } => {
+                // A selector whose variants are all numbers / CLDR plural
+                // categories forces the selected variable to `Number`.
+                let typ = if variants.iter().all(|v| v.is_number()) {
+                    VarType::Number
+                } else {
+                    VarType::Any
+                };
+                self.visit_inline(selector, typ);
+                for variant in variants {
+                    self.visit_pattern(&variant.value);
+                }
+            }
+        }
+    }
+
+    /// Walk an inline expression. `ctx` is the type to assign to a bare
+    /// `$variable` found directly here (e.g. `Number` for a numeric selector).
+    fn visit_inline(&mut self, inline: &ast::InlineExpression<&str>, ctx: VarType) {
+        match inline {
+            ast::InlineExpression::VariableReference { id } => self.add(id.name, ctx),
+            ast::InlineExpression::FunctionReference { id, arguments } => {
+                // `NUMBER()` formats its positional argument as a number.
+                let positional = if id.name == "NUMBER" {
+                    VarType::Number
+                } else {
+                    ctx
+                };
+                self.visit_call_arguments(arguments, positional);
+            }
+            ast::InlineExpression::TermReference { arguments, .. } => {
+                if let Some(arguments) = arguments {
+                    self.visit_call_arguments(arguments, VarType::Any);
+                }
+            }
+            ast::InlineExpression::Placeable { expression } => self.visit_expression(expression),
+            // Literals and message references contain no variables.
+            ast::InlineExpression::StringLiteral { .. }
+            | ast::InlineExpression::NumberLiteral { .. }
+            | ast::InlineExpression::MessageReference { .. } => {}
+        }
+    }
+
+    /// Positional arguments inherit `positional`; named option values are only
+    /// ever `Any` — they configure the call, they are not the formatted value.
+    fn visit_call_arguments(&mut self, arguments: &ast::CallArguments<&str>, positional: VarType) {
+        for arg in &arguments.positional {
+            self.visit_inline(arg, positional);
+        }
+        for named in &arguments.named {
+            self.visit_inline(&named.value, VarType::Any);
+        }
+    }
 }
 
 pub fn find_attributes<'ast>(attributes: &'ast [ast::Attribute<&'ast str>]) -> Vec<Attribute> {

--- a/src/l10n_bundle.rs
+++ b/src/l10n_bundle.rs
@@ -34,6 +34,10 @@ impl L10nBundle {
         let lang_id: LanguageIdentifier = lang.as_ref().parse().map_err(|e| format!("{e:?}"))?;
         let mut bundle = FluentBundle::new(vec![lang_id]);
         bundle.set_use_isolating(use_isolating);
+        // Register the FTL builtins (`NUMBER`, …). Without this, any message
+        // using `{ NUMBER($x) }` fails to format and `msg`/`attr` return an
+        // `Err`, which the generated accessors `.unwrap()` into a panic.
+        bundle.add_builtins().map_err(|e| format!("{e:?}"))?;
         let resource = FluentResource::try_new(ftl).map_err(|e| format!("{e:?}"))?;
         bundle
             .add_resource(resource)

--- a/src/tests/ast/mod.rs
+++ b/src/tests/ast/mod.rs
@@ -1,6 +1,7 @@
 mod attrib_only;
 mod msg_element;
 mod msg_number;
+mod msg_number_fn;
 mod msg_select;
 mod msg_select_num;
 mod msg_string;

--- a/src/tests/ast/msg_number_fn.rs
+++ b/src/tests/ast/msg_number_fn.rs
@@ -1,0 +1,139 @@
+use super::assert_gen;
+use crate::build::typed::*;
+use crate::tests::ast::AstResourceExt;
+use fluent_syntax::ast;
+use fluent_syntax::parser;
+
+// A `NUMBER()` call marks its argument as a number, so `$ratio` must be
+// detected as a variable *and* typed `Number` — see README "Type deduction".
+const FTL: &str = r#"
+
+dpi-ratio = Your DPI ratio is { NUMBER($ratio) }
+
+"#;
+
+/// From: https://docs.rs/fluent-syntax/0.12.0/fluent_syntax/ast/enum.InlineExpression.html
+#[test]
+fn ast() {
+    let resource = parser::parse(FTL).expect("Failed to parse an FTL resource.");
+
+    assert_eq!(
+        resource.body[0],
+        ast::Entry::Message(ast::Message {
+            id: ast::Identifier { name: "dpi-ratio" },
+            value: Some(ast::Pattern {
+                elements: vec![
+                    ast::PatternElement::TextElement {
+                        value: "Your DPI ratio is "
+                    },
+                    ast::PatternElement::Placeable {
+                        expression: ast::Expression::Inline(
+                            ast::InlineExpression::FunctionReference {
+                                id: ast::Identifier { name: "NUMBER" },
+                                arguments: ast::CallArguments {
+                                    positional: vec![ast::InlineExpression::VariableReference {
+                                        id: ast::Identifier { name: "ratio" }
+                                    }],
+                                    named: vec![],
+                                }
+                            }
+                        )
+                    },
+                ]
+            }),
+            attributes: vec![],
+            comment: None,
+        }),
+    );
+}
+
+#[test]
+fn typed() {
+    let resource = parser::parse(FTL).expect("Failed to parse an FTL resource.");
+    let message = resource.first_message();
+
+    println!("{message:#?}");
+    assert_eq!(
+        message,
+        Message {
+            id: Id::new_msg("dpi-ratio"),
+            comment: vec![],
+            variables: vec![Variable {
+                id: "ratio".to_string(),
+                typ: VarType::Number,
+            }],
+            elements: vec![],
+        }
+    );
+}
+
+#[test]
+fn typed_gen() {
+    assert_gen(module_path!(), "test", FTL);
+}
+
+/// The README's `your-rank` example: a `NUMBER()` function reference used as a
+/// select selector. `$pos` appears in the selector and in four variant bodies;
+/// it must be collected exactly once and typed `Number`.
+#[test]
+fn typed_number_function_selector() {
+    let ftl = r#"
+your-rank = { NUMBER($pos, type: "ordinal") ->
+   [1] You finished first!
+   [one] You finished {$pos}st
+   [two] You finished {$pos}nd
+   [few] You finished {$pos}rd
+  *[other] You finished {$pos}th
+}
+"#;
+    let resource = parser::parse(ftl).expect("Failed to parse an FTL resource.");
+    let message = resource.first_message();
+
+    println!("{message:#?}");
+    assert_eq!(
+        message,
+        Message {
+            id: Id::new_msg("your-rank"),
+            comment: vec![],
+            variables: vec![Variable {
+                id: "pos".to_string(),
+                typ: VarType::Number,
+            }],
+            elements: vec![],
+        }
+    );
+}
+
+/// A variable referenced only inside a select variant body — never in the
+/// selector — must still be collected as an argument.
+#[test]
+fn typed_variable_only_in_variant() {
+    let ftl = r#"
+status = { $state ->
+    [active]   { $detail } is running
+   *[inactive] stopped
+}
+"#;
+    let resource = parser::parse(ftl).expect("Failed to parse an FTL resource.");
+    let message = resource.first_message();
+
+    println!("{message:#?}");
+    assert_eq!(
+        message,
+        Message {
+            id: Id::new_msg("status"),
+            comment: vec![],
+            variables: vec![
+                Variable {
+                    id: "state".to_string(),
+                    typ: VarType::Any,
+                },
+                Variable {
+                    id: "detail".to_string(),
+                    typ: VarType::Any,
+                },
+            ],
+            elements: vec![],
+        }
+    );
+}

--- a/src/tests/gen/msg_number_fn_gen.ftl
+++ b/src/tests/gen/msg_number_fn_gen.ftl
@@ -1,0 +1,4 @@
+
+
+dpi-ratio = Your DPI ratio is { NUMBER($ratio) }
+

--- a/src/tests/gen/msg_number_fn_gen.rs
+++ b/src/tests/gen/msg_number_fn_gen.rs
@@ -1,0 +1,125 @@
+// This file is generated. Do not edit it manually.
+use crate::prelude::*;
+use std::{
+    fmt::Display,
+    ops::{Deref, Range},
+    slice::Iter,
+    str::FromStr,
+};
+
+static LANG_DATA: &[u8] = include_bytes!("msg_number_fn_gen.ftl");
+
+static ALL_LANGS: [L10n; 1] = [
+    // languages as an array
+    L10n::En,
+];
+
+static EN: LanguageIdentifier = langid!("en");
+
+/// The languages that have translations available.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum L10n {
+    En,
+}
+
+impl Default for L10n {
+    fn default() -> Self {
+        Self::En
+    }
+}
+
+impl FromStr for L10n {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "en" => Ok(Self::En),
+            _ => Err(format!("Unknown language: {}", s)),
+        }
+    }
+}
+
+impl Deref for L10n {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::En => "en",
+        }
+    }
+}
+
+impl AsRef<LanguageIdentifier> for L10n {
+    fn as_ref(&self) -> &LanguageIdentifier {
+        match self {
+            Self::En => &EN,
+        }
+    }
+}
+
+impl AsRef<str> for L10n {
+    fn as_ref(&self) -> &str {
+        self
+    }
+}
+
+impl Display for L10n {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.deref())
+    }
+}
+
+impl L10n {
+    pub fn iter() -> Iter<'static, L10n> {
+        ALL_LANGS.iter()
+    }
+
+    /// Negotiate the best language to use based on the `Accept-Language` header.
+    ///
+    /// Falls back to the default language if none of the languages in the header are available.
+    pub fn langneg(accept_language: &str) -> L10n {
+        negotiate_languages(accept_language, &ALL_LANGS)
+    }
+
+    fn byte_range(&self) -> Range<usize> {
+        match self {
+            Self::En => 0..52,
+        }
+    }
+    /// Load a L10nLanguage from the embedded data.
+    pub fn load(&self) -> L10nLanguage {
+        let bytes = LANG_DATA[self.byte_range()].to_vec();
+        L10nLanguage::new(self, &bytes).unwrap()
+    }
+
+    /// Load all languages (L10nLanguage) from the embedded data.
+    pub fn load_all() -> L10nLanguageVec {
+        L10nLanguageVec::load(
+            LANG_DATA,
+            Self::iter().map(|lang| (lang, lang.byte_range())),
+        )
+        .unwrap()
+    }
+}
+
+/// A thin wrapper around the Fluent messages for one language.
+///
+/// It provides functions for each message that was found in
+/// all the languages at build time.
+pub struct L10nLanguage(L10nBundle);
+
+impl L10nLanguage {
+    /// Load the L10n resources for the given language. The language
+    /// has to be a valid LanguageIdentifier or otherwise
+    /// an error is returned.
+    ///
+    /// The bytes are expected to be the contents of a .ftl file
+    pub fn new(lang: impl AsRef<str>, bytes: &[u8]) -> Result<Self, String> {
+        Ok(Self(L10nBundle::new(lang, bytes)?))
+    }
+
+    pub fn msg_dpi_ratio<F0: Into<FluentNumber>>(&self, ratio: F0) -> String {
+        let mut args = FluentArgs::new();
+        args.set("ratio", ratio.into());
+        self.0.msg("dpi-ratio", Some(args)).unwrap()
+    }
+}

--- a/src/tests/runtime.rs
+++ b/src/tests/runtime.rs
@@ -126,6 +126,21 @@ fn msg_segments_pads_lone_placeable_for_bidi_isolation() {
 }
 
 #[test]
+fn number_builtin_is_registered() {
+    // `NUMBER()` is an FTL builtin; it must be registered on the bundle or the
+    // message fails to format and `msg` returns an `Err`. See README
+    // "Type deduction".
+    let ftl = "dpi-ratio = Your DPI ratio is { NUMBER($ratio) }\n";
+    let bundle = L10nBundle::new("en", ftl.as_bytes()).unwrap();
+    let mut args = FluentArgs::new();
+    args.set("ratio", 2);
+    assert_eq!(
+        bundle.msg("dpi-ratio", Some(args)).unwrap(),
+        "Your DPI ratio is \u{2068}2\u{2069}"
+    );
+}
+
+#[test]
 fn language_vec_loads_each_range() {
     let en = "greeting = Hello\n";
     let de = "greeting = Hallo\n";

--- a/src/tests/snapshots/fluent_typed__tests__msg_number_fn.snap
+++ b/src/tests/snapshots/fluent_typed__tests__msg_number_fn.snap
@@ -1,0 +1,129 @@
+---
+source: src/tests/mod.rs
+expression: generated
+---
+// This file is generated. Do not edit it manually.
+use crate::prelude::*;
+use std::{
+    fmt::Display,
+    ops::{Deref, Range},
+    slice::Iter,
+    str::FromStr,
+};
+
+static LANG_DATA: &[u8] = include_bytes!("msg_number_fn_gen.ftl");
+
+static ALL_LANGS: [L10n; 1] = [
+    // languages as an array
+    L10n::En,
+];
+
+static EN: LanguageIdentifier = langid!("en");
+
+/// The languages that have translations available.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum L10n {
+    En,
+}
+
+impl Default for L10n {
+    fn default() -> Self {
+        Self::En
+    }
+}
+
+impl FromStr for L10n {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "en" => Ok(Self::En),
+            _ => Err(format!("Unknown language: {}", s)),
+        }
+    }
+}
+
+impl Deref for L10n {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::En => "en",
+        }
+    }
+}
+
+impl AsRef<LanguageIdentifier> for L10n {
+    fn as_ref(&self) -> &LanguageIdentifier {
+        match self {
+            Self::En => &EN,
+        }
+    }
+}
+
+impl AsRef<str> for L10n {
+    fn as_ref(&self) -> &str {
+        self
+    }
+}
+
+impl Display for L10n {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.deref())
+    }
+}
+
+impl L10n {
+    pub fn iter() -> Iter<'static, L10n> {
+        ALL_LANGS.iter()
+    }
+
+    /// Negotiate the best language to use based on the `Accept-Language` header.
+    ///
+    /// Falls back to the default language if none of the languages in the header are available.
+    pub fn langneg(accept_language: &str) -> L10n {
+        negotiate_languages(accept_language, &ALL_LANGS)
+    }
+
+    fn byte_range(&self) -> Range<usize> {
+        match self {
+            Self::En => 0..52,
+        }
+    }
+    /// Load a L10nLanguage from the embedded data.
+    pub fn load(&self) -> L10nLanguage {
+        let bytes = LANG_DATA[self.byte_range()].to_vec();
+        L10nLanguage::new(self, &bytes).unwrap()
+    }
+
+    /// Load all languages (L10nLanguage) from the embedded data.
+    pub fn load_all() -> L10nLanguageVec {
+        L10nLanguageVec::load(
+            LANG_DATA,
+            Self::iter().map(|lang| (lang, lang.byte_range())),
+        )
+        .unwrap()
+    }
+}
+
+/// A thin wrapper around the Fluent messages for one language.
+///
+/// It provides functions for each message that was found in
+/// all the languages at build time.
+pub struct L10nLanguage(L10nBundle);
+
+impl L10nLanguage {
+    /// Load the L10n resources for the given language. The language
+    /// has to be a valid LanguageIdentifier or otherwise
+    /// an error is returned.
+    ///
+    /// The bytes are expected to be the contents of a .ftl file
+    pub fn new(lang: impl AsRef<str>, bytes: &[u8]) -> Result<Self, String> {
+        Ok(Self(L10nBundle::new(lang, bytes)?))
+    }
+
+    pub fn msg_dpi_ratio<F0: Into<FluentNumber>>(&self, ratio: F0) -> String {
+        let mut args = FluentArgs::new();
+        args.set("ratio", ratio.into());
+        self.0.msg("dpi-ratio", Some(args)).unwrap()
+    }
+}


### PR DESCRIPTION
## Problem

The README documents `NUMBER()` as a number type-deduction trigger
(`dpi-ratio = ... { NUMBER($ratio) }`, plus the "Type deduction" section),
but it was never implemented. `find_variable_references` only matched a bare
`VariableReference` and a `Select` whose selector was a `VariableReference` —
it never recursed. Consequences:

- `{ NUMBER($ratio) }` — `$ratio` was not detected at all; the generated
  accessor silently omitted the parameter.
- `{ NUMBER($pos, type: "ordinal") -> ... }` (the README `your-rank` example)
  — the selector is a `FunctionReference`, so it fell through.
- A variable referenced only inside a select variant body was also missed.

While fixing this I found a **second, related bug**: `L10nBundle` never
registered the FTL builtins, so `fluent-bundle`'s `NUMBER` function was
unknown. Any message using `{ NUMBER($x) }` failed to format, and the
generated accessor's `.unwrap()` **panicked** when called. Without this fix,
the type-deduction fix above would generate a parameter whose accessor panics.

## Changes

- **`find_variable_references`** rewritten as a recursive AST walker
  (`VarCollector`) that descends into selects (selector *and* every variant
  body), function- and term-call arguments, and nested placeables. Variables
  are deduplicated by id, keeping the most specific type — `Number` (from a
  `NUMBER()` call or an all-numeric selector) is never downgraded to `Any`.
- **`L10nBundle::build`** now calls `bundle.add_builtins()`, registering
  `NUMBER` so messages using it format correctly.
- `VarType` derives `Copy` (a fieldless enum) so the inferred type can be
  threaded through the recursion.

## Tests

- `src/tests/ast/msg_number_fn.rs` — covers all three reported scenarios:
  `NUMBER($ratio)`, the README `your-rank` `NUMBER()` selector (dedup +
  `Number`), and a variable used only inside a variant body.
- `src/tests/runtime.rs::number_builtin_is_registered` — proves `NUMBER()`
  formats end to end at runtime.

All 65 unit tests + the playground integration test pass; `clippy` and `fmt`
are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)