### PR TITLE
Add FTL comment linting and default-locale type sourcing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 ## Unreleased
 
 ### Added
+- Comment linting. `LintLevel` (`Off` / `Warn` / `Deny` / `Strict`) and
+  `BuildOptions::with_lint_level()`. fluent-typed now checks `.ftl` comments for
+  typo'd type keywords (`(Numbr)`), annotations of variables the message does
+  not have, type-annotation comments detached from their message by a blank
+  line, and (ineffective) type annotations in non-default locales — reporting
+  the file and line of each. `Deny` turns these into hard build errors; `Strict`
+  also requires every variable of every generated message to resolve to a
+  concrete type.
+- `BuildError::DefaultLanguageNotFound` and `BuildError::Lint` variants.
 - Structured (`(Element)`) messages: annotate a variable or term with
   `(Element)` to have fluent-typed generate a struct of resolved text segments
   split at those points, instead of a single `String`. Variable elements are
@@ -15,9 +24,21 @@
   `L10nLanguageVec::load_without_isolation()` constructors.
 
 ### Changed
-- **Breaking:** `BuildOptions` has a new `use_isolating` field (default
-  `true`). Direct struct construction must include this field;
-  `BuildOptions::default()` users are unaffected.
+- **Breaking:** message argument types are now read from the **default locale**
+  only. Previously each locale was typed from its own comments and a message was
+  dropped when locales disagreed; now the default locale defines the contract
+  and other locales need only a compatible *set* of variables, not matching type
+  comments. Type comments in non-default locales no longer affect output (the
+  linter flags them). The generated doc comments now always come from the
+  default locale.
+- **Breaking:** `BuildError::FtlParse` is now a struct variant
+  `{ path, errors }` — was a tuple `FtlParse(String)` — and reports the file and
+  the line of each parse error. `BuildError::DuplicateKey` gains `original_line`
+  and `duplicate_line` fields and its message now includes line numbers.
+- **Breaking:** `BuildOptions` has a new `lint_level` field (default
+  `LintLevel::Warn`) and a new `use_isolating` field (default `true`). Direct
+  struct construction must include these fields; `BuildOptions::default()`
+  users are unaffected.
 
 ### Removed
 - **Breaking:** the `Pattern<String>` output mode and everything tied to it —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
   also requires every variable of every generated message to resolve to a
   concrete type.
 - `BuildError::DefaultLanguageNotFound` and `BuildError::Lint` variants.
+- `BuildError::Multiple` — parse errors, unreadable files and duplicate keys are
+  now collected across every `.ftl` file and reported together, instead of the
+  build failing on the first one encountered.
 - Structured (`(Element)`) messages: annotate a variable or term with
   `(Element)` to have fluent-typed generate a struct of resolved text segments
   split at those points, instead of a single `String`. Variable elements are

--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ When using translation keys, there is often no easy way to know if they are bein
 correctly and if they are being used at all. This project generates, using the `fluent` ast,
 the function definitions for the translation keys in a fluent file.
 
-In order to guarantee the safeness, funtions are only generated for messages that
-are found in all the locales. For those only found for some locales
-or if the signature of the messages are different a warning is printed.
+To guarantee safety, an accessor is generated only for a message that is present
+in every locale with a compatible set of variables. The **default locale**
+(configured in `BuildOptions`) is the single source of truth for each message's
+argument types. A message missing from a locale, or one whose variables differ,
+is skipped — with a warning naming the `.ftl` file and line.
 
 Each locale's ftl resources are appended into a single ftl file, and you can configure it
 to either embed all of them into the binary with accessors suitable both for server-side
@@ -133,7 +135,14 @@ let greeting = languages.get(L10n::En).msg("greeting", None).unwrap();
 ## Type deduction
 
 Since the fluent syntax doesn't explicitly specify the type of the translation variables, this
-project uses the following rules to infer the type of the translation variables:
+project uses the following rules to infer the type of the translation variables.
+
+Types are read from the **default locale** only (set with
+`BuildOptions::with_default_language`, `en` by default). A type comment in any
+other locale has no effect — the [linter](#linting) flags it. Translators never
+need to maintain type metadata.
+
+The rules:
 
 - String:
   - If a variable's comment contains `(String)`, as in `# $name (String) - The name.`
@@ -152,6 +161,37 @@ your-rank = { NUMBER($pos, type: "ordinal") ->
   *[other] You finished {$pos}th
 }
 ```
+
+## Linting
+
+Because argument types come from message comments, a mistake in a comment would
+otherwise silently leave a variable untyped. The linter catches the common ones
+and reports the `.ftl` file and line of each:
+
+- a typo'd keyword — `(Numbr)` instead of `(Number)`;
+- an annotation of a variable the message doesn't have — `# $nme` vs `$name`;
+- a type-annotation comment detached from its message by a blank line;
+- a type annotation in a non-default locale, where it has no effect.
+
+`BuildOptions::with_lint_level` controls how strict the check is:
+
+- `LintLevel::Off` — no lint diagnostics.
+- `LintLevel::Warn` (the default) — problems are reported as `cargo::warning=`
+  lines; the build still succeeds.
+- `LintLevel::Deny` — comment mistakes in the default locale become hard build
+  errors. An untyped variable is still allowed.
+- `LintLevel::Strict` — like `Deny`, and additionally every variable of every
+  generated message must resolve to a concrete type (via a `(String)`/`(Number)`
+  comment, a `NUMBER()` call or a plural selector). An untyped variable fails
+  the build.
+
+```rust,ignore
+// in build.rs
+let options = BuildOptions::default().with_lint_level(LintLevel::Strict);
+```
+
+Diagnostics about non-default locales stay warnings even under `Strict` — they
+concern translator-owned files and must never block a build.
 
 ## Structured messages
 

--- a/src/build/builder.rs
+++ b/src/build/builder.rs
@@ -150,13 +150,22 @@ fn from_locales_folder(
     };
     let locales_dir = fs::read_dir(folder).map_err(map_io)?;
     let mut locales = Vec::new();
+    let mut errors: Vec<BuildError> = Vec::new();
     for entry in locales_dir {
         let entry = entry.map_err(map_io)?;
         let path = entry.path();
         if path.is_dir() {
             let lang = path.file_name().unwrap().to_str().unwrap();
-            locales.push(LangBundle::from_folder(&path, lang, deny_duplicate_keys)?);
+            // Collect every locale's errors rather than stopping at the first,
+            // so one rebuild surfaces them all.
+            match LangBundle::from_folder(&path, lang, deny_duplicate_keys) {
+                Ok(bundle) => locales.push(bundle),
+                Err(errs) => errors.extend(errs),
+            }
         }
+    }
+    if !errors.is_empty() {
+        return Err(BuildError::collapse(errors));
     }
     if locales.is_empty() {
         return Err(BuildError::NoLocaleFolders {

--- a/src/build/builder.rs
+++ b/src/build/builder.rs
@@ -1,4 +1,7 @@
-use super::{Analyzed, BuildError, BuildOptions, LangBundle, Message, r#gen::generate, typed::Id};
+use super::{
+    Analyzed, BuildError, BuildOptions, LangBundle, LintLevel, Message, r#gen::generate, lint,
+    typed::Id,
+};
 use std::{collections::HashSet, fs};
 
 pub struct Builder {
@@ -41,16 +44,25 @@ impl Builder {
     }
 
     pub fn generate(&self) -> Result<(), BuildError> {
-        let analyzed = Analyzed::from(&self.langbundles);
+        // The default locale is the single source of truth for every message's
+        // typed signature, so it must exist.
+        let default = self
+            .langbundles
+            .iter()
+            .find(|b| b.language_id == self.options.default_language)
+            .ok_or_else(|| BuildError::DefaultLanguageNotFound {
+                language: self.options.default_language.clone(),
+                folder: self.options.locales_folder.clone(),
+            })?;
 
-        for warn in analyzed.missing_messages {
+        let analyzed = Analyzed::from(&self.langbundles, default);
+        for warn in &analyzed.warnings {
             println!("cargo::warning={warn}");
         }
-        for warn in analyzed.signature_mismatches {
-            println!("cargo::warning={warn}");
-        }
 
-        let messages = &self.messages(&analyzed.common);
+        self.run_lints(default, &analyzed.common)?;
+
+        let messages = &self.messages(default, &analyzed.common);
         let generated = generate(&self.options, &self.langbundles, messages)
             .map_err(BuildError::Generation)?
             .replace("    ", &self.options.indentation);
@@ -80,14 +92,51 @@ impl Builder {
         Ok(())
     }
 
-    fn messages(&self, common: &HashSet<Id>) -> Vec<&Message> {
-        let mut added = HashSet::new();
-        self.langbundles
+    /// Run the comment lints and report them according to the configured
+    /// [`LintLevel`]. Returns an error only in strict mode, when there are
+    /// hard lint failures.
+    fn run_lints(&self, default: &LangBundle, common: &HashSet<Id>) -> Result<(), BuildError> {
+        let lints = lint::check(&self.langbundles, default, common);
+
+        match self.options.lint_level {
+            LintLevel::Off => {}
+            LintLevel::Warn => {
+                for w in lints.mistakes.iter().chain(&lints.ineffective) {
+                    println!("cargo::warning={w}");
+                }
+            }
+            LintLevel::Deny | LintLevel::Strict => {
+                // Diagnostics about non-default locales stay warnings — they
+                // concern translator-owned files.
+                for w in &lints.ineffective {
+                    println!("cargo::warning={w}");
+                }
+                let mut errors = lints.mistakes;
+                // `Strict` additionally requires every variable to be typed.
+                if self.options.lint_level == LintLevel::Strict {
+                    errors.extend(lints.untyped);
+                }
+                if !errors.is_empty() {
+                    errors.sort();
+                    return Err(BuildError::Lint { messages: errors });
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// The messages to generate: the default locale's, in declaration order,
+    /// restricted to the ids that survived cross-locale analysis. An id is
+    /// emitted only once, even if duplicate keys were allowed and the default
+    /// locale defines it more than once.
+    fn messages<'a>(&self, default: &'a LangBundle, common: &HashSet<Id>) -> Vec<&'a Message> {
+        let mut seen = HashSet::new();
+        default
+            .messages
             .iter()
-            .flat_map(|r| &r.messages)
             .filter(|msg| common.contains(&msg.id))
-            .filter(|msg| added.insert(&msg.id))
-            .collect::<Vec<_>>()
+            .filter(|msg| seen.insert(&msg.id))
+            .collect()
     }
 }
 

--- a/src/build/error.rs
+++ b/src/build/error.rs
@@ -2,7 +2,11 @@ use std::{error::Error, fmt, io, path::PathBuf};
 
 #[derive(Debug)]
 pub enum BuildError {
-    FtlParse(String),
+    FtlParse {
+        path: PathBuf,
+        /// One entry per parse error, each prefixed with its line number.
+        errors: Vec<String>,
+    },
     FtlRead {
         path: PathBuf,
         source: io::Error,
@@ -10,7 +14,9 @@ pub enum BuildError {
     DuplicateKey {
         key: String,
         original: PathBuf,
+        original_line: usize,
         duplicate: PathBuf,
+        duplicate_line: usize,
     },
     LocalesFolder {
         folder: String,
@@ -18,6 +24,16 @@ pub enum BuildError {
     },
     NoLocaleFolders {
         folder: String,
+    },
+    DefaultLanguageNotFound {
+        language: String,
+        folder: String,
+    },
+    /// One or more lint diagnostics, raised as a hard error under
+    /// [`crate::LintLevel::Deny`] or [`crate::LintLevel::Strict`]. Each entry
+    /// already carries `file:line`.
+    Lint {
+        messages: Vec<String>,
     },
     WriteOutput {
         path: String,
@@ -30,27 +46,37 @@ pub enum BuildError {
 impl fmt::Display for BuildError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::FtlParse(msg) => write!(f, "Could not parse ftl: {msg}"),
+            Self::FtlParse { path, errors } => {
+                write!(f, "Could not parse '{}':", path.display())?;
+                for e in errors {
+                    write!(f, "\n  {e}")?;
+                }
+                Ok(())
+            }
             Self::FtlRead { path, .. } => {
                 write!(f, "Could not read '{}'", path.display())
             }
             Self::DuplicateKey {
                 key,
                 original,
+                original_line,
                 duplicate,
+                duplicate_line,
             } => {
                 if original == duplicate {
                     write!(
                         f,
-                        "Duplicate message key '{key}' in '{}'",
-                        duplicate.display()
+                        "Duplicate message key '{key}' in '{}': lines {original_line} and \
+                         {duplicate_line}",
+                        duplicate.display(),
                     )
                 } else {
                     write!(
                         f,
-                        "Duplicate message key '{key}' in '{}', first defined in '{}'",
+                        "Duplicate message key '{key}' in '{}:{duplicate_line}', first defined \
+                         in '{}:{original_line}'",
                         duplicate.display(),
-                        original.display()
+                        original.display(),
                     )
                 }
             }
@@ -63,6 +89,20 @@ impl fmt::Display for BuildError {
                     "No locale subfolders found in '{folder}'. Expected \
                      '<lang-id>/<resource>.ftl' files, e.g. 'en/main.ftl'."
                 )
+            }
+            Self::DefaultLanguageNotFound { language, folder } => {
+                write!(
+                    f,
+                    "Default language '{language}' has no locale subfolder in '{folder}'. \
+                     Set it with `BuildOptions::with_default_language`."
+                )
+            }
+            Self::Lint { messages } => {
+                write!(f, "fluent-typed found {} lint error(s):", messages.len())?;
+                for m in messages {
+                    write!(f, "\n  {m}")?;
+                }
+                Ok(())
             }
             Self::WriteOutput { path, .. } => {
                 write!(f, "Could not write file '{path}'")

--- a/src/build/error.rs
+++ b/src/build/error.rs
@@ -41,6 +41,21 @@ pub enum BuildError {
     },
     Rustfmt(String),
     Generation(String),
+    /// Several independent build errors, collected so they can all be fixed in
+    /// one pass instead of one rebuild at a time.
+    Multiple(Vec<BuildError>),
+}
+
+impl BuildError {
+    /// Collapse a list of errors into one: the error itself when there is
+    /// exactly one, otherwise a [`BuildError::Multiple`].
+    pub(crate) fn collapse(mut errors: Vec<BuildError>) -> BuildError {
+        if errors.len() == 1 {
+            errors.pop().unwrap()
+        } else {
+            BuildError::Multiple(errors)
+        }
+    }
 }
 
 impl fmt::Display for BuildError {
@@ -109,6 +124,19 @@ impl fmt::Display for BuildError {
             }
             Self::Rustfmt(msg) => write!(f, "Rustfmt error: {msg}"),
             Self::Generation(msg) => write!(f, "{msg}"),
+            Self::Multiple(errors) => {
+                write!(f, "{} build errors:", errors.len())?;
+                for e in errors {
+                    for (i, line) in e.to_string().lines().enumerate() {
+                        if i == 0 {
+                            write!(f, "\n  - {line}")?;
+                        } else {
+                            write!(f, "\n    {line}")?;
+                        }
+                    }
+                }
+                Ok(())
+            }
         }
     }
 }

--- a/src/build/gen/ext.rs
+++ b/src/build/gen/ext.rs
@@ -3,7 +3,6 @@ pub trait StrExt {
     fn rust_static_name(&self) -> String;
     fn rust_var_name(&self) -> String;
     fn rust_id(&self) -> String;
-    fn with_semicolon(&self) -> String;
 }
 
 impl StrExt for str {
@@ -50,9 +49,5 @@ impl StrExt for str {
             }
         }
         s
-    }
-
-    fn with_semicolon(&self) -> String {
-        format!("{self};")
     }
 }

--- a/src/build/gen/message.rs
+++ b/src/build/gen/message.rs
@@ -2,19 +2,6 @@ use crate::build::r#gen::StrExt;
 use crate::build::typed::{ElementKind, ElementMarker, Message, VarType, Variable};
 
 impl Message {
-    pub fn trait_signature(&self) -> String {
-        let mut out = Vec::new();
-        let func_name = self.id.func_name();
-        out.push(self.comment_lines());
-        let mut sig = self.signature(&self.variables, &func_name);
-        if !self.elements.is_empty() {
-            sig.push_str(&format!(" /* elements: {} */", self.elements_summary()));
-        }
-        out.push(sig.with_semicolon());
-
-        out.join("\n")
-    }
-
     fn signature(&self, variables: &[Variable], func_name: &str) -> String {
         if variables.is_empty() {
             format!(r"    pub fn {func_name}(&self) -> String")
@@ -98,21 +85,6 @@ impl Message {
             .map(|c| format!("    /// {c}\n"))
             .collect::<Vec<_>>()
             .join("")
-    }
-
-    /// A short, human-readable summary of the `(Element)` layout. Used so that
-    /// cross-locale signature-mismatch warnings reflect element order.
-    fn elements_summary(&self) -> String {
-        let parts = self
-            .elements
-            .iter()
-            .map(|m| match m.kind {
-                ElementKind::Variable => format!("${}", m.name),
-                ElementKind::Term => format!("-{}", m.name),
-            })
-            .collect::<Vec<_>>()
-            .join(", ");
-        format!("[{parts}]")
     }
 
     /// The ordered struct fields for a structured (element) message: a text

--- a/src/build/gen/mod.rs
+++ b/src/build/gen/mod.rs
@@ -69,14 +69,8 @@ static ALL_LANGS: [L10n; {}] = [
     replacements.push(("<<placeholder enum variant>>", enum_variants));
 
     // ///////////////////////////
-
-    if !langs.contains(&options.default_language.as_str()) {
-        return Err(format!(
-            "Default language '{}' not found in locales",
-            options.default_language
-        ));
-    }
-
+    // `Builder::generate` has already verified that the default language is
+    // present in the locales.
     let default_lang = format!(
         "        Self::{}",
         &options.default_language.rust_var_name()

--- a/src/build/lang_bundle.rs
+++ b/src/build/lang_bundle.rs
@@ -37,20 +37,35 @@ impl LangBundle {
         let path = PathBuf::from(name);
         let ast = parse_ftl(ftl, &path)?;
         let mut seen = HashMap::new();
+        let mut errors = Vec::new();
+        let messages = to_messages(
+            &ast,
+            deny_duplicate_keys,
+            &mut seen,
+            &path,
+            ftl,
+            &mut errors,
+        );
+        if !errors.is_empty() {
+            return Err(BuildError::collapse(errors));
+        }
         Ok(LangBundle {
             language_name: lang_name(&ast),
             language_id: lang.to_string(),
-            messages: to_messages(&ast, deny_duplicate_keys, &mut seen, &path, ftl)?,
+            messages,
             standalone_comments: standalone_comments(&ast, ftl, &path.display().to_string()),
             ftl: ftl.to_string(),
         })
     }
 
+    /// Load every `.ftl` file of one locale folder. Parse errors, unreadable
+    /// files and duplicate keys are *collected* across all files rather than
+    /// failing on the first, so a single rebuild surfaces them all.
     pub fn from_folder(
         folder: &Path,
         lang: &str,
         deny_duplicate_keys: bool,
-    ) -> Result<Self, BuildError> {
+    ) -> Result<Self, Vec<BuildError>> {
         let mut bundle = LangBundle {
             language_name: None,
             language_id: lang.to_string(),
@@ -58,24 +73,41 @@ impl LangBundle {
             standalone_comments: Vec::new(),
             ftl: String::new(),
         };
+        let mut errors: Vec<BuildError> = Vec::new();
 
-        let mut paths = folder
+        let mut paths = match folder
             .gather_all_files(|file| file.extension().map(|s| s == "ftl") == Some(true))
-            .map_err(|e| BuildError::FtlRead {
-                path: folder.to_path_buf(),
-                source: std::io::Error::other(e.to_string()),
-            })?;
-
+        {
+            Ok(paths) => paths,
+            Err(e) => {
+                return Err(vec![BuildError::FtlRead {
+                    path: folder.to_path_buf(),
+                    source: std::io::Error::other(e.to_string()),
+                }]);
+            }
+        };
         paths.sort();
 
         let mut seen: HashMap<String, (PathBuf, usize)> = HashMap::new();
 
         for path in paths {
-            let ftl = fs::read_to_string(&path).map_err(|e| BuildError::FtlRead {
-                path: path.clone(),
-                source: e,
-            })?;
-            let ast = parse_ftl(&ftl, &path)?;
+            let ftl = match fs::read_to_string(&path) {
+                Ok(ftl) => ftl,
+                Err(e) => {
+                    errors.push(BuildError::FtlRead {
+                        path: path.clone(),
+                        source: e,
+                    });
+                    continue;
+                }
+            };
+            let ast = match parse_ftl(&ftl, &path) {
+                Ok(ast) => ast,
+                Err(e) => {
+                    errors.push(e);
+                    continue;
+                }
+            };
 
             if let Some(lang_name) = lang_name(&ast)
                 && bundle.language_name.is_none()
@@ -95,10 +127,22 @@ impl LangBundle {
                 .standalone_comments
                 .extend(standalone_comments(&ast, &ftl, &file));
 
-            let messages = to_messages(&ast, deny_duplicate_keys, &mut seen, &path, &ftl)?;
+            let messages = to_messages(
+                &ast,
+                deny_duplicate_keys,
+                &mut seen,
+                &path,
+                &ftl,
+                &mut errors,
+            );
             bundle.messages.extend(messages);
         }
-        Ok(bundle)
+
+        if errors.is_empty() {
+            Ok(bundle)
+        } else {
+            Err(errors)
+        }
     }
 }
 
@@ -121,38 +165,40 @@ fn format_parse_error(src: &str, error: &ParserError) -> String {
     )
 }
 
+/// Parse the messages of one resource file. Duplicate keys are pushed onto
+/// `errors` (and the duplicate is skipped) rather than aborting, so every
+/// duplicate in the locale is reported.
 fn to_messages(
     ast: &Resource<&str>,
     deny_duplicate_keys: bool,
     seen: &mut HashMap<String, (PathBuf, usize)>,
     path: &Path,
     src: &str,
-) -> Result<Vec<Message>, BuildError> {
+    errors: &mut Vec<BuildError>,
+) -> Vec<Message> {
     let file = path.display().to_string();
-    ast.body
-        .iter()
-        .filter_map(|entry| match entry {
-            Entry::Message(m) => Some(Message::parse(m, src, &file)),
-            _ => None,
-        })
-        .flatten()
-        .map(|msg| {
+    let mut messages = Vec::new();
+    for entry in &ast.body {
+        let Entry::Message(m) = entry else { continue };
+        for msg in Message::parse(m, src, &file) {
             if deny_duplicate_keys {
                 let seen_key = msg.id.to_string();
                 if let Some((original, original_line)) = seen.get(&seen_key) {
-                    return Err(BuildError::DuplicateKey {
+                    errors.push(BuildError::DuplicateKey {
                         key: msg.id.message.clone(),
                         original: original.clone(),
                         original_line: *original_line,
                         duplicate: path.to_path_buf(),
                         duplicate_line: msg.line,
                     });
+                    continue;
                 }
                 seen.insert(seen_key, (path.to_path_buf(), msg.line));
             }
-            Ok(msg)
-        })
-        .collect()
+            messages.push(msg);
+        }
+    }
+    messages
 }
 
 /// Collect the lines of every standalone `#` comment (an `Entry::Comment` — a

--- a/src/build/lang_bundle.rs
+++ b/src/build/lang_bundle.rs
@@ -1,17 +1,28 @@
-use crate::build::utils::Traversable;
+use crate::build::utils::{Traversable, line_at_byte, line_of};
 
 use super::{BuildError, Message};
-use fluent_syntax::ast::Resource;
-use fluent_syntax::parser;
+use fluent_syntax::ast::{Entry, Resource};
+use fluent_syntax::parser::{self, ParserError};
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
+
+/// A single line of a standalone `#` comment — one that is *not* attached to a
+/// message. Used by the linter to flag type annotations detached from their
+/// message by a blank line.
+#[derive(Debug, Clone)]
+pub struct CommentLine {
+    pub file: String,
+    pub line: usize,
+    pub text: String,
+}
 
 #[derive(Debug)]
 pub struct LangBundle {
     pub language_name: Option<String>,
     pub language_id: String,
     pub messages: Vec<Message>,
+    pub standalone_comments: Vec<CommentLine>,
     pub ftl: String,
 }
 
@@ -23,16 +34,18 @@ impl LangBundle {
         lang: &str,
         deny_duplicate_keys: bool,
     ) -> Result<Self, BuildError> {
-        let ast = parser::parse(ftl).map_err(|e| BuildError::FtlParse(format!("{e:?}")))?;
         let path = PathBuf::from(name);
+        let ast = parse_ftl(ftl, &path)?;
         let mut seen = HashMap::new();
         Ok(LangBundle {
             language_name: lang_name(&ast),
             language_id: lang.to_string(),
-            messages: to_messages(&ast, deny_duplicate_keys, &mut seen, &path)?,
+            messages: to_messages(&ast, deny_duplicate_keys, &mut seen, &path, ftl)?,
+            standalone_comments: standalone_comments(&ast, ftl, &path.display().to_string()),
             ftl: ftl.to_string(),
         })
     }
+
     pub fn from_folder(
         folder: &Path,
         lang: &str,
@@ -42,6 +55,7 @@ impl LangBundle {
             language_name: None,
             language_id: lang.to_string(),
             messages: Vec::new(),
+            standalone_comments: Vec::new(),
             ftl: String::new(),
         };
 
@@ -54,15 +68,14 @@ impl LangBundle {
 
         paths.sort();
 
-        let mut seen: HashMap<String, PathBuf> = HashMap::new();
+        let mut seen: HashMap<String, (PathBuf, usize)> = HashMap::new();
 
         for path in paths {
             let ftl = fs::read_to_string(&path).map_err(|e| BuildError::FtlRead {
                 path: path.clone(),
                 source: e,
             })?;
-            let ast =
-                parser::parse(ftl.as_str()).map_err(|e| BuildError::FtlParse(format!("{e:?}")))?;
+            let ast = parse_ftl(&ftl, &path)?;
 
             if let Some(lang_name) = lang_name(&ast)
                 && bundle.language_name.is_none()
@@ -77,41 +90,87 @@ impl LangBundle {
             bundle.ftl.push_str(&ftl);
             bundle.ftl.push('\n');
 
-            let messages = to_messages(&ast, deny_duplicate_keys, &mut seen, &path)?;
+            let file = path.display().to_string();
+            bundle
+                .standalone_comments
+                .extend(standalone_comments(&ast, &ftl, &file));
+
+            let messages = to_messages(&ast, deny_duplicate_keys, &mut seen, &path, &ftl)?;
             bundle.messages.extend(messages);
         }
         Ok(bundle)
     }
 }
 
+/// Parse an FTL string, turning any parse errors into a [`BuildError::FtlParse`]
+/// that names the file and the line of each error.
+fn parse_ftl<'a>(ftl: &'a str, path: &Path) -> Result<Resource<&'a str>, BuildError> {
+    parser::parse(ftl).map_err(|(_, errors)| BuildError::FtlParse {
+        path: path.to_path_buf(),
+        errors: errors.iter().map(|e| format_parse_error(ftl, e)).collect(),
+    })
+}
+
+fn format_parse_error(src: &str, error: &ParserError) -> String {
+    // `error.pos.start` is a raw byte offset that may land inside a multi-byte
+    // character, so it must not be used to slice `src` directly.
+    format!(
+        "line {}: {:?}",
+        line_at_byte(src, error.pos.start),
+        error.kind
+    )
+}
+
 fn to_messages(
     ast: &Resource<&str>,
     deny_duplicate_keys: bool,
-    seen: &mut HashMap<String, PathBuf>,
+    seen: &mut HashMap<String, (PathBuf, usize)>,
     path: &Path,
+    src: &str,
 ) -> Result<Vec<Message>, BuildError> {
+    let file = path.display().to_string();
     ast.body
         .iter()
         .filter_map(|entry| match entry {
-            fluent_syntax::ast::Entry::Message(m) => Some(Message::parse(m)),
+            Entry::Message(m) => Some(Message::parse(m, src, &file)),
             _ => None,
         })
         .flatten()
         .map(|msg| {
             if deny_duplicate_keys {
                 let seen_key = msg.id.to_string();
-                if let Some(original) = seen.get(&seen_key) {
+                if let Some((original, original_line)) = seen.get(&seen_key) {
                     return Err(BuildError::DuplicateKey {
                         key: msg.id.message.clone(),
                         original: original.clone(),
+                        original_line: *original_line,
                         duplicate: path.to_path_buf(),
+                        duplicate_line: msg.line,
                     });
                 }
-                seen.insert(seen_key, path.to_path_buf());
+                seen.insert(seen_key, (path.to_path_buf(), msg.line));
             }
             Ok(msg)
         })
         .collect()
+}
+
+/// Collect the lines of every standalone `#` comment (an `Entry::Comment` — a
+/// comment not attached to a message).
+fn standalone_comments(ast: &Resource<&str>, src: &str, file: &str) -> Vec<CommentLine> {
+    let mut out = Vec::new();
+    for entry in &ast.body {
+        if let Entry::Comment(comment) = entry {
+            for line in &comment.content {
+                out.push(CommentLine {
+                    file: file.to_owned(),
+                    line: line_of(src, line),
+                    text: (*line).to_owned(),
+                });
+            }
+        }
+    }
+    out
 }
 
 fn lang_name(ast: &Resource<&str>) -> Option<String> {
@@ -119,7 +178,7 @@ fn lang_name(ast: &Resource<&str>) -> Option<String> {
     ast.body
         .iter()
         .filter_map(|entry| match entry {
-            fluent_syntax::ast::Entry::Message(m) => {
+            Entry::Message(m) => {
                 if m.id.name != "language-name" || !m.attributes.is_empty() {
                     return None;
                 }

--- a/src/build/lang_bundle.rs
+++ b/src/build/lang_bundle.rs
@@ -156,10 +156,11 @@ fn parse_ftl<'a>(ftl: &'a str, path: &Path) -> Result<Resource<&'a str>, BuildEr
 }
 
 fn format_parse_error(src: &str, error: &ParserError) -> String {
-    // `error.pos.start` is a raw byte offset that may land inside a multi-byte
-    // character, so it must not be used to slice `src` directly.
+    // `error.kind` is formatted with `Display` (a human-readable sentence from
+    // fluent-syntax), not `Debug`. `error.pos.start` is a raw byte offset that
+    // may land inside a multi-byte character, so it must not slice `src`.
     format!(
-        "line {}: {:?}",
+        "line {}: {}",
         line_at_byte(src, error.pos.start),
         error.kind
     )

--- a/src/build/lint.rs
+++ b/src/build/lint.rs
@@ -1,0 +1,199 @@
+//! Lints over the parsed `.ftl` locales.
+//!
+//! fluent-typed reads argument types from message comments. A mistake in a
+//! comment — a typo'd keyword, a misnamed variable, a comment detached from its
+//! message — otherwise fails silently. These lints surface them, with the file
+//! and line of every problem. See [`crate::LintLevel`] for how they are
+//! reported.
+
+use std::collections::HashSet;
+
+use crate::build::LangBundle;
+use crate::build::typed::{
+    Annotation, ElementKind, Id, Message, Ref, RefKind, VarType, annotation,
+};
+
+/// Every lint diagnostic produced from the parsed locales.
+pub struct Lints {
+    /// L1/L2/L3 — comment mistakes in the default locale. Reported as warnings
+    /// under [`crate::LintLevel::Warn`], as hard errors under
+    /// [`crate::LintLevel::Strict`].
+    pub mistakes: Vec<String>,
+    /// L5 — type annotations in non-default locales, which never affect output.
+    /// Always a warning, even in strict mode (it concerns translator files).
+    pub ineffective: Vec<String>,
+    /// Variables of generated messages that have no concrete type. Used only
+    /// under [`crate::LintLevel::Strict`].
+    pub untyped: Vec<String>,
+}
+
+/// Run every lint. `default` is the default-language bundle (whose comments are
+/// the type contract); `common` is the set of message ids that get generated.
+pub fn check(langs: &[LangBundle], default: &LangBundle, common: &HashSet<Id>) -> Lints {
+    let mut mistakes = Vec::new();
+    for msg in &default.messages {
+        mistakes.extend(comment_mistakes(msg, &default.messages));
+    }
+    mistakes.extend(detached_comments(default));
+    mistakes.sort();
+
+    let mut ineffective = Vec::new();
+    for lang in langs {
+        if lang.language_id != default.language_id {
+            ineffective.extend(ineffective_annotations(lang));
+        }
+    }
+    ineffective.sort();
+
+    // Variables a message entry deliberately annotated `(Element)`. They are
+    // intentional positional gaps, not "untyped by neglect", so the strict
+    // untyped check must not flag them — including where an attribute reuses
+    // the same name (attributes keep the variable as a runtime argument).
+    let element_vars: HashSet<(&str, &str)> = default
+        .messages
+        .iter()
+        .flat_map(|m| {
+            m.elements
+                .iter()
+                .filter(|e| e.kind == ElementKind::Variable)
+                .map(move |e| (m.id.message.as_str(), e.name.as_str()))
+        })
+        .collect();
+
+    let mut untyped = Vec::new();
+    for msg in &default.messages {
+        if common.contains(&msg.id) {
+            untyped.extend(untyped_variables(msg, &element_vars));
+        }
+    }
+    untyped.sort();
+
+    Lints {
+        mistakes,
+        ineffective,
+        untyped,
+    }
+}
+
+/// L1 (typo'd keyword) and L2 (annotation of a non-existent variable/term),
+/// scanning one message's comment. `all` is every message of the default
+/// locale, so an annotation pointing at an *attribute*'s variable is seen too.
+fn comment_mistakes(msg: &Message, all: &[Message]) -> Vec<String> {
+    if msg.comment.is_empty() {
+        return Vec::new();
+    }
+    let refs: Vec<&Ref> = all
+        .iter()
+        .filter(|m| m.id.message == msg.id.message)
+        .flat_map(|m| &m.pattern_refs)
+        .collect();
+
+    let mut out = Vec::new();
+    for (i, line) in msg.comment.iter().enumerate() {
+        let Some(a) = annotation(line) else { continue };
+        let at = format!("{}:{}", msg.file, msg.comment_line + i);
+        if a.is_recognized() {
+            if !target_exists(&a, &refs) {
+                out.push(format!(
+                    "{at}: comment annotates {}{} but {} references no such {}",
+                    a.sigil(),
+                    a.name,
+                    msg.id,
+                    if a.is_term { "term" } else { "variable" },
+                ));
+            }
+        } else if a.is_type_annotation() {
+            // Shaped like a type annotation, keyword is a near-miss typo.
+            out.push(format!(
+                "{at}: unrecognized type annotation '({})' for {}{} — expected \
+                 (String), (Number) or (Element)",
+                a.keyword,
+                a.sigil(),
+                a.name,
+            ));
+        }
+        // Otherwise the parentheses are ordinary prose — not an annotation.
+    }
+    out
+}
+
+fn target_exists(a: &Annotation, refs: &[&Ref]) -> bool {
+    let kind = if a.is_term {
+        RefKind::Term
+    } else {
+        RefKind::Variable
+    };
+    refs.iter().any(|r| r.kind == kind && r.name == a.name)
+}
+
+/// L3 — a standalone comment in the default locale shaped like a type
+/// annotation: a blank line has detached it from its message, so it is inert.
+fn detached_comments(default: &LangBundle) -> Vec<String> {
+    default
+        .standalone_comments
+        .iter()
+        .filter_map(|c| {
+            let a = annotation(&c.text)?;
+            if !a.is_type_annotation() {
+                return None;
+            }
+            Some(format!(
+                "{}:{}: type annotation '{}{} ({})' is detached from its message \
+                 by a blank line and has no effect",
+                c.file,
+                c.line,
+                a.sigil(),
+                a.name,
+                a.keyword,
+            ))
+        })
+        .collect()
+}
+
+/// L5 — type annotations in a non-default locale, which never affect output.
+fn ineffective_annotations(lang: &LangBundle) -> Vec<String> {
+    let report = |file: &str, line: usize, a: &Annotation| {
+        format!(
+            "{file}:{line}: type annotation '{}{} ({})' in non-default locale \
+             '{}' has no effect — type comments only apply to the default locale",
+            a.sigil(),
+            a.name,
+            a.keyword,
+            lang.language_id,
+        )
+    };
+
+    let mut out = Vec::new();
+    for msg in &lang.messages {
+        for (i, line) in msg.comment.iter().enumerate() {
+            if let Some(a) = annotation(line).filter(|a| a.is_type_annotation()) {
+                out.push(report(&msg.file, msg.comment_line + i, &a));
+            }
+        }
+    }
+    for c in &lang.standalone_comments {
+        if let Some(a) = annotation(&c.text).filter(|a| a.is_type_annotation()) {
+            out.push(report(&c.file, c.line, &a));
+        }
+    }
+    out
+}
+
+/// Strict-only — every variable of a generated message must resolve to a
+/// concrete type. An attribute's variables are typed via the parent message's
+/// comment, so they are checked here too. Variables annotated `(Element)`
+/// (listed in `element_vars` as `(message, variable)` pairs) are skipped.
+fn untyped_variables(msg: &Message, element_vars: &HashSet<(&str, &str)>) -> Vec<String> {
+    msg.variables
+        .iter()
+        .filter(|v| v.typ == VarType::Any)
+        .filter(|v| !element_vars.contains(&(msg.id.message.as_str(), v.id.as_str())))
+        .map(|v| {
+            format!(
+                "{}:{}: variable ${} in {} has no type — add a \
+                 '# ${} (String)' or '# ${} (Number)' comment",
+                msg.file, msg.line, v.id, msg.id, v.id, v.id,
+            )
+        })
+        .collect()
+}

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -2,13 +2,14 @@ mod builder;
 mod error;
 pub mod r#gen;
 mod lang_bundle;
+pub mod lint;
 pub mod options;
 pub mod typed;
 mod utils;
 mod validations;
 
 pub use error::BuildError;
-pub use options::{BuildOptions, FtlOutputOptions};
+pub use options::{BuildOptions, FtlOutputOptions, LintLevel};
 use std::process::ExitCode;
 
 // Crate-internal: the `build` module itself is private, so these are not part

--- a/src/build/options/build_options.rs
+++ b/src/build/options/build_options.rs
@@ -1,4 +1,5 @@
 use super::ftl_output_options::FtlOutputOptions;
+use super::lint_level::LintLevel;
 
 const DEFAULT_PREFIX: &str = "msg_";
 
@@ -47,6 +48,11 @@ pub struct BuildOptions {
     /// Defaults to true.
     pub deny_duplicate_keys: bool,
 
+    /// How strictly the comments in your `.ftl` files are checked.
+    ///
+    /// Defaults to [`LintLevel::Warn`].
+    pub lint_level: LintLevel,
+
     /// Whether the generated code wraps interpolated variables in Unicode
     /// bidi isolation marks (FSI `U+2068` / PDI `U+2069`).
     ///
@@ -69,6 +75,7 @@ impl Default for BuildOptions {
             format: true,
             prefix: DEFAULT_PREFIX.to_string(),
             deny_duplicate_keys: true,
+            lint_level: LintLevel::default(),
             use_isolating: true,
         }
     }
@@ -114,6 +121,13 @@ impl BuildOptions {
 
     pub fn with_allow_duplicate_keys(mut self) -> Self {
         self.deny_duplicate_keys = false;
+        self
+    }
+
+    /// Set how strictly the comments in your `.ftl` files are checked.
+    /// See [`LintLevel`].
+    pub fn with_lint_level(mut self, level: LintLevel) -> Self {
+        self.lint_level = level;
         self
     }
 

--- a/src/build/options/lint_level.rs
+++ b/src/build/options/lint_level.rs
@@ -1,0 +1,25 @@
+/// How strictly fluent-typed checks the comments in your `.ftl` files.
+///
+/// fluent-typed infers argument types from message comments
+/// (`# $name (String) - ...`). Mistakes in those comments — a typo'd keyword,
+/// a misnamed variable, a comment detached from its message — otherwise fail
+/// silently. The lint level controls what happens when one is found.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum LintLevel {
+    /// No lint diagnostics are emitted at all.
+    Off,
+    /// Lint problems are reported as `cargo::warning=` lines. The default.
+    #[default]
+    Warn,
+    /// Comment mistakes in the default locale become hard build errors, but an
+    /// untyped variable is still allowed. Use this to enforce correct comments
+    /// without also requiring every variable to be type-annotated.
+    ///
+    /// Diagnostics about non-default locales stay warnings: they concern
+    /// translator-owned files and must never block a build.
+    Deny,
+    /// Like [`LintLevel::Deny`], and additionally every variable of every
+    /// generated message must resolve to a concrete type (`String` or
+    /// `Number`) — an untyped variable fails the build.
+    Strict,
+}

--- a/src/build/options/mod.rs
+++ b/src/build/options/mod.rs
@@ -1,5 +1,7 @@
 mod build_options;
 mod ftl_output_options;
+mod lint_level;
 
 pub use build_options::BuildOptions;
 pub use ftl_output_options::FtlOutputOptions;
+pub use lint_level::LintLevel;

--- a/src/build/typed/mod.rs
+++ b/src/build/typed/mod.rs
@@ -5,7 +5,9 @@ use std::fmt::Display;
 
 use crate::build::r#gen::StrExt;
 
-#[derive(Debug, PartialEq)]
+pub use type_in_comment::{Annotation, annotation};
+
+#[derive(Debug)]
 pub struct Message {
     pub id: Id,
     pub comment: Vec<String>,
@@ -13,6 +15,45 @@ pub struct Message {
     /// The `(Element)`-annotated split points, in the order they appear in the
     /// message pattern. Empty for ordinary (non-structured) messages.
     pub elements: Vec<ElementMarker>,
+    /// Every `$variable` and `-term` reference in the message pattern, in
+    /// document order, derived purely from the AST (independent of comments).
+    /// Used for comment-independent cross-locale compatibility checks.
+    pub pattern_refs: Vec<Ref>,
+    /// The `.ftl` file this message was parsed from (for diagnostics).
+    pub file: String,
+    /// The 1-based line of the message (or attribute) id.
+    pub line: usize,
+    /// The 1-based line of the first comment line, or `0` when there is no
+    /// comment. Comment blocks are contiguous, so `comment[i]` is at
+    /// `comment_line + i`.
+    pub comment_line: usize,
+}
+
+/// Equality compares the *semantic* shape of a message — its id, comment,
+/// variables, elements and pattern references — and deliberately ignores the
+/// source-location fields (`file`, `line`, `comment_line`), which are diagnostic
+/// metadata rather than identity.
+impl PartialEq for Message {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+            && self.comment == other.comment
+            && self.variables == other.variables
+            && self.elements == other.elements
+            && self.pattern_refs == other.pattern_refs
+    }
+}
+
+/// A `$variable` or `-term` reference in a message pattern.
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub struct Ref {
+    pub name: String,
+    pub kind: RefKind,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
+pub enum RefKind {
+    Variable,
+    Term,
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
@@ -56,12 +97,6 @@ impl Id {
             .unwrap_or_default();
         format!("{}{atr}", self.message).rust_id()
     }
-}
-
-#[derive(Debug, PartialEq)]
-pub struct Attribute {
-    pub id: String,
-    pub variables: Vec<Variable>,
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]

--- a/src/build/typed/parse_ast.rs
+++ b/src/build/typed/parse_ast.rs
@@ -1,57 +1,150 @@
 use super::*;
+use crate::build::utils::line_of;
 use fluent_syntax::ast;
 use type_in_comment::TypeInComment;
 
 impl Message {
-    pub fn parse(message: &ast::Message<&str>) -> Vec<Self> {
+    /// Parse an AST message into one `Message` for its value (if any) plus one
+    /// per attribute. `src` is the full FTL source the message was parsed from
+    /// (used to recover line numbers) and `file` is its path (for diagnostics).
+    pub fn parse(message: &ast::Message<&str>, src: &str, file: &str) -> Vec<Self> {
         let mut found = Vec::new();
         let comment = message
             .comment
             .as_ref()
             .map(|v| v.content.iter().map(|s| s.to_string()).collect::<Vec<_>>())
             .unwrap_or_default();
+        let comment_line = message
+            .comment
+            .as_ref()
+            .and_then(|c| c.content.first())
+            .map(|first| line_of(src, first))
+            .unwrap_or(0);
+        let tic = TypeInComment::parse(&comment);
+
         if let Some(value) = message.value.as_ref() {
             let mut variables = find_variable_references(value);
-            let tic = TypeInComment::parse(&comment);
             tic.update_types(&mut variables);
             let elements = find_elements(value, tic.element_vars(), tic.element_terms());
             // Element variables are positional gaps, not function arguments.
-            variables.retain(|v| !tic.element_vars().contains(&v.id));
-            let id = Id {
-                message: message.id.name.to_owned(),
-                attribute: None,
-            };
+            // Retain on the elements `find_elements` actually matched (a
+            // top-level placeable), so an `(Element)` annotation on a name
+            // that is not a real element placeable leaves the variable as an
+            // ordinary argument rather than dropping it from both lists.
+            let element_var_names: Vec<&str> = elements
+                .iter()
+                .filter(|e| e.kind == ElementKind::Variable)
+                .map(|e| e.name.as_str())
+                .collect();
+            variables.retain(|v| !element_var_names.contains(&v.id.as_str()));
             found.push(Self {
-                id,
-                comment,
+                id: Id {
+                    message: message.id.name.to_owned(),
+                    attribute: None,
+                },
+                comment: comment.clone(),
                 variables,
                 elements,
+                pattern_refs: find_refs(value),
+                file: file.to_owned(),
+                line: line_of(src, message.id.name),
+                comment_line,
             });
         }
-        for attribute in find_attributes(&message.attributes) {
-            let variables = attribute.variables;
-            let id = Id {
-                message: message.id.name.to_owned(),
-                attribute: Some(attribute.id.to_owned()),
-            };
+        for (idx, attribute) in message.attributes.iter().enumerate() {
+            // The message comment also types the attributes' variables — a
+            // fluent attribute cannot carry a comment of its own.
+            let mut variables = find_variable_references(&attribute.value);
+            tic.update_types(&mut variables);
+            // A message with no value of its own produced no value-Message to
+            // carry its comment; attach it to the first attribute so the
+            // linter can still inspect that comment.
+            let carries_comment = message.value.is_none() && idx == 0;
             found.push(Self {
-                id,
-                comment: vec![],
+                id: Id {
+                    message: message.id.name.to_owned(),
+                    attribute: Some(attribute.id.name.to_owned()),
+                },
+                comment: if carries_comment {
+                    comment.clone()
+                } else {
+                    vec![]
+                },
                 variables,
                 elements: vec![],
+                pattern_refs: find_refs(&attribute.value),
+                file: file.to_owned(),
+                line: line_of(src, attribute.id.name),
+                comment_line: if carries_comment { comment_line } else { 0 },
             });
         }
         found
     }
 }
 
-impl Attribute {
-    pub fn parse(attribute: &ast::Attribute<&str>) -> Self {
-        let variables = find_variable_references(&attribute.value);
-        Self {
-            id: attribute.id.name.to_owned(),
-            variables,
+/// Collect every `$variable` and `-term` reference in a pattern, in document
+/// order, **independent of comments**. Walks the same depth as
+/// [`find_variable_references`] (selects, variants, call arguments, nested
+/// placeables). The result is used for comment-independent cross-locale
+/// compatibility checks; it is intentionally not deduplicated, so a repeated
+/// reference (e.g. the same `(Element)` used twice) is preserved.
+pub fn find_refs(pattern: &ast::Pattern<&str>) -> Vec<Ref> {
+    let mut refs = Vec::new();
+    collect_refs_pattern(pattern, &mut refs);
+    refs
+}
+
+fn collect_refs_pattern(pattern: &ast::Pattern<&str>, refs: &mut Vec<Ref>) {
+    for element in &pattern.elements {
+        if let ast::PatternElement::Placeable { expression } = element {
+            collect_refs_expr(expression, refs);
         }
+    }
+}
+
+fn collect_refs_expr(expression: &ast::Expression<&str>, refs: &mut Vec<Ref>) {
+    match expression {
+        ast::Expression::Inline(inline) => collect_refs_inline(inline, refs),
+        ast::Expression::Select { selector, variants } => {
+            collect_refs_inline(selector, refs);
+            for variant in variants {
+                collect_refs_pattern(&variant.value, refs);
+            }
+        }
+    }
+}
+
+fn collect_refs_inline(inline: &ast::InlineExpression<&str>, refs: &mut Vec<Ref>) {
+    match inline {
+        ast::InlineExpression::VariableReference { id } => refs.push(Ref {
+            name: id.name.to_owned(),
+            kind: RefKind::Variable,
+        }),
+        ast::InlineExpression::TermReference { id, arguments, .. } => {
+            refs.push(Ref {
+                name: id.name.to_owned(),
+                kind: RefKind::Term,
+            });
+            if let Some(arguments) = arguments {
+                collect_refs_call_arguments(arguments, refs);
+            }
+        }
+        ast::InlineExpression::FunctionReference { arguments, .. } => {
+            collect_refs_call_arguments(arguments, refs)
+        }
+        ast::InlineExpression::Placeable { expression } => collect_refs_expr(expression, refs),
+        ast::InlineExpression::StringLiteral { .. }
+        | ast::InlineExpression::NumberLiteral { .. }
+        | ast::InlineExpression::MessageReference { .. } => {}
+    }
+}
+
+fn collect_refs_call_arguments(arguments: &ast::CallArguments<&str>, refs: &mut Vec<Ref>) {
+    for arg in &arguments.positional {
+        collect_refs_inline(arg, refs);
+    }
+    for named in &arguments.named {
+        collect_refs_inline(&named.value, refs);
     }
 }
 
@@ -157,10 +250,6 @@ impl VarCollector {
             self.visit_inline(&named.value, VarType::Any);
         }
     }
-}
-
-pub fn find_attributes<'ast>(attributes: &'ast [ast::Attribute<&'ast str>]) -> Vec<Attribute> {
-    attributes.iter().map(Attribute::parse).collect()
 }
 
 /// Walk the pattern and collect the `(Element)`-annotated placeables, in order.

--- a/src/build/typed/type_in_comment.rs
+++ b/src/build/typed/type_in_comment.rs
@@ -49,6 +49,113 @@ impl TypeInComment {
     }
 }
 
+/// An annotation-shaped comment line: a `$variable` or `-term`, followed by a
+/// parenthesized keyword — e.g. `$name (String) - the user's name`.
+///
+/// This describes the *shape* only; the `keyword` may be a typo. Use
+/// [`Annotation::is_recognized`] to tell whether it actually means something.
+#[derive(Debug, PartialEq)]
+pub struct Annotation<'a> {
+    /// The referenced name, without its `$` / `-` sigil.
+    pub name: &'a str,
+    /// `true` when the sigil was `-` (a term) rather than `$` (a variable).
+    pub is_term: bool,
+    /// The keyword found between the parentheses, e.g. `String` or `Numbr`.
+    pub keyword: &'a str,
+}
+
+impl Annotation<'_> {
+    /// `true` when this annotation is one fluent-typed actually acts on:
+    /// `(Element)` on a variable or term, or `(String)`/`(Number)` on a
+    /// variable. Anything else (a typo, `(String)` on a term, …) is inert.
+    pub fn is_recognized(&self) -> bool {
+        match self.keyword {
+            "Element" => true,
+            "String" | "Number" => !self.is_term,
+            _ => false,
+        }
+    }
+
+    /// `true` when this line was *plausibly meant* to be a type annotation —
+    /// either a recognized one, or a near-miss typo of a real keyword.
+    ///
+    /// This distinguishes a botched annotation (`(Numbr)`, `(string)`) from
+    /// ordinary prose that merely contains parentheses (`(optional)`,
+    /// `(max 99)`). The linter must only flag the former.
+    pub fn is_type_annotation(&self) -> bool {
+        self.is_recognized() || looks_like_keyword(self.keyword)
+    }
+
+    /// The sigil that introduced the reference: `"$"` or `"-"`.
+    pub fn sigil(&self) -> &'static str {
+        if self.is_term { "-" } else { "$" }
+    }
+}
+
+/// Whether `keyword` is close enough to a real type keyword (`String`,
+/// `Number`, `Element`) to be a typo of it rather than ordinary prose.
+/// Case-insensitive, Levenshtein distance up to 2.
+fn looks_like_keyword(keyword: &str) -> bool {
+    let kw = keyword.trim().to_ascii_lowercase();
+    ["string", "number", "element"]
+        .iter()
+        .any(|target| edit_distance_within(&kw, target, 2))
+}
+
+/// `true` when the Levenshtein edit distance between `a` and `b` is `<= max`.
+/// Bails out early once every cell of a row exceeds `max`.
+fn edit_distance_within(a: &str, b: &str, max: usize) -> bool {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    if a.len().abs_diff(b.len()) > max {
+        return false;
+    }
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    let mut curr: Vec<usize> = vec![0; b.len() + 1];
+    for (i, ca) in a.iter().enumerate() {
+        curr[0] = i + 1;
+        let mut row_min = curr[0];
+        for (j, cb) in b.iter().enumerate() {
+            let cost = usize::from(ca != cb);
+            curr[j + 1] = (prev[j] + cost).min(prev[j + 1] + 1).min(curr[j] + 1);
+            row_min = row_min.min(curr[j + 1]);
+        }
+        if row_min > max {
+            return false;
+        }
+        std::mem::swap(&mut prev, &mut curr);
+    }
+    prev[b.len()] <= max
+}
+
+/// Parse a single comment line as a type annotation, if it is shaped like one.
+///
+/// A line is annotation-shaped when its first whitespace-delimited token is a
+/// `$variable` / `-term` reference and the remainder begins with a
+/// `(keyword)`. The keyword is returned verbatim — recognized or not — so the
+/// linter can flag typos.
+pub fn annotation(line: &str) -> Option<Annotation<'_>> {
+    let (id, rest) = line.trim().split_once(' ')?;
+    let id = id.trim();
+
+    let is_term = id.starts_with('-');
+    let is_var = id.starts_with('$');
+    if !is_term && !is_var {
+        return None;
+    }
+    let name = &id[1..];
+    if name.is_empty() {
+        return None;
+    }
+
+    let keyword = rest.trim().strip_prefix('(')?.split_once(')')?.0.trim();
+    Some(Annotation {
+        name,
+        is_term,
+        keyword,
+    })
+}
+
 enum Found<'a> {
     String(&'a str),
     Number(&'a str),
@@ -58,32 +165,15 @@ enum Found<'a> {
 }
 
 fn parse_line(line: &str) -> Found<'_> {
-    let Some((id, rest)) = line.trim().split_once(' ') else {
+    let Some(a) = annotation(line) else {
         return Found::Nothing;
     };
-
-    let id = id.trim();
-    let rest = rest.trim();
-
-    let is_term = id.starts_with('-');
-    let is_var = id.starts_with('$');
-    if !is_term && !is_var {
-        return Found::Nothing;
-    }
-    let name = &id[1..];
-
-    if rest.starts_with("(Element)") {
-        if is_term {
-            Found::ElementTerm(name)
-        } else {
-            Found::ElementVar(name)
-        }
-    } else if is_var && rest.starts_with("(Number)") {
-        Found::Number(name)
-    } else if is_var && rest.starts_with("(String)") {
-        Found::String(name)
-    } else {
-        Found::Nothing
+    match a.keyword {
+        "Element" if a.is_term => Found::ElementTerm(a.name),
+        "Element" => Found::ElementVar(a.name),
+        "Number" if !a.is_term => Found::Number(a.name),
+        "String" if !a.is_term => Found::String(a.name),
+        _ => Found::Nothing,
     }
 }
 
@@ -113,4 +203,42 @@ fn test_element_var_and_term() {
     let tic = TypeInComment::parse(&lines);
     assert_eq!(tic.element_vars(), ["icon".to_string()]);
     assert_eq!(tic.element_terms(), ["privacy-link".to_string()]);
+}
+
+#[test]
+fn test_annotation_shape_and_recognition() {
+    let good = annotation("$name (String) - the user's name").unwrap();
+    assert_eq!(good.name, "name");
+    assert!(!good.is_term);
+    assert_eq!(good.keyword, "String");
+    assert!(good.is_recognized());
+
+    // A spaced keyword is trimmed and still recognized.
+    let spaced = annotation("$name ( String ) - desc").unwrap();
+    assert_eq!(spaced.keyword, "String");
+    assert!(spaced.is_recognized());
+
+    // Annotation-shaped, but a typo'd keyword — still a *type annotation*.
+    let typo = annotation("$count (Numbr)").unwrap();
+    assert_eq!(typo.keyword, "Numbr");
+    assert!(!typo.is_recognized());
+    assert!(typo.is_type_annotation());
+
+    // `(Number)` on a term is inert, but still a (botched) type annotation.
+    let on_term = annotation("-brand (Number)").unwrap();
+    assert!(on_term.is_term);
+    assert!(!on_term.is_recognized());
+    assert!(on_term.is_type_annotation());
+
+    // A parenthesized word that is just prose is NOT a type annotation, so the
+    // linter must not flag it as a typo.
+    for prose in ["$name (optional) - desc", "$count (max 99)", "$x ()"] {
+        let a = annotation(prose).unwrap();
+        assert!(!a.is_recognized(), "{prose}");
+        assert!(!a.is_type_annotation(), "{prose}");
+    }
+
+    // Plain prose is not annotation-shaped at all.
+    assert!(annotation("$name - the user's name").is_none());
+    assert!(annotation("just a comment").is_none());
 }

--- a/src/build/utils.rs
+++ b/src/build/utils.rs
@@ -1,6 +1,35 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
+/// The 1-based line number of `sub` within `src`.
+///
+/// `fluent_syntax` parses a `Resource<&str>` whose every `&str` is a subslice of
+/// the source FTL string, so the line of any AST node is recoverable by pointer
+/// arithmetic. Returns `0` if `sub` is not a subslice of `src` (a defensive
+/// fallback that should never happen for AST-derived slices).
+pub fn line_of(src: &str, sub: &str) -> usize {
+    let offset = (sub.as_ptr() as usize).wrapping_sub(src.as_ptr() as usize);
+    if offset > src.len() {
+        return 0;
+    }
+    line_at_byte(src, offset)
+}
+
+/// The 1-based line number at byte `offset` within `src`.
+///
+/// `offset` need not fall on a UTF-8 char boundary — the count is taken over
+/// raw bytes, and a newline is always a single ASCII byte. This makes it safe
+/// for byte offsets that come straight from a parser (e.g. error positions),
+/// which a `&str` slice would reject.
+pub fn line_at_byte(src: &str, offset: usize) -> usize {
+    let offset = offset.min(src.len());
+    src.as_bytes()[..offset]
+        .iter()
+        .filter(|&&b| b == b'\n')
+        .count()
+        + 1
+}
+
 pub trait Traversable {
     fn gather_all_files(
         &self,
@@ -41,4 +70,15 @@ fn gather_paths_recursive(
         }
     }
     Ok(())
+}
+
+#[test]
+fn line_at_byte_accepts_an_offset_inside_a_multibyte_char() {
+    // `é` occupies bytes 3..5; `\n` is at byte 5.
+    let src = "café\nx\n";
+    // Offset 4 lands *inside* `é` — must not panic (a `&str` slice would).
+    assert_eq!(line_at_byte(src, 4), 1);
+    assert_eq!(line_at_byte(src, 6), 2);
+    // An out-of-range offset is clamped, not a panic.
+    assert_eq!(line_at_byte(src, 999), 3);
 }

--- a/src/build/validations.rs
+++ b/src/build/validations.rs
@@ -1,112 +1,157 @@
 use std::collections::{HashMap, HashSet};
 
-use crate::{
-    build::LangBundle,
-    build::typed::{ElementMarker, Id, Variable},
-};
+use crate::build::LangBundle;
+use crate::build::typed::{ElementKind, Id, Message, RefKind};
 
-/// A message's cross-locale signature: its argument variables together with its
-/// ordered `(Element)` layout. Two locales' messages are compatible only when
-/// both match.
-type Signature<'a> = (&'a [Variable], &'a [ElementMarker]);
-
+/// The result of comparing every locale against the default-locale contract.
 #[derive(Debug)]
 pub struct Analyzed {
+    /// The message ids that will be generated: defined in the default locale,
+    /// present in every other locale, and structurally compatible everywhere.
     pub common: HashSet<Id>,
-    pub missing_messages: Vec<String>,
-    pub signature_mismatches: Vec<String>,
+    /// Human-readable warnings for messages that could *not* be generated.
+    /// Each names the `.ftl` file and line involved. Sorted for determinism.
+    pub warnings: Vec<String>,
 }
+
 impl Analyzed {
-    pub fn from(langs: &[LangBundle]) -> Self {
-        let common_ids = common_message_ids(langs);
-        let missing_messages = missing_message_ids(&common_ids, langs);
-        let (signature_mismatches, ids) = signature_mismatches(&common_ids, langs);
-        let common: HashSet<Id> = common_ids.difference(&ids).cloned().collect();
-        Self {
-            common,
-            missing_messages,
-            signature_mismatches,
-        }
-    }
-}
+    /// Analyze the locales against `default`, the default-language bundle.
+    ///
+    /// The default locale defines each message's contract (its variables and
+    /// `(Element)` layout). A message is generated only when every other locale
+    /// defines it too, with a structurally compatible pattern.
+    pub fn from(langs: &[LangBundle], default: &LangBundle) -> Self {
+        let others: Vec<&LangBundle> = langs
+            .iter()
+            .filter(|l| l.language_id != default.language_id)
+            .collect();
 
-fn signature_mismatches(
-    common_ids: &HashSet<Id>,
-    langs: &[LangBundle],
-) -> (Vec<String>, HashSet<Id>) {
-    let mut messages = vec![];
-    let mut mismatched_ids = HashSet::new();
+        let mut common = HashSet::new();
+        let mut warnings = Vec::new();
 
-    for id in common_ids {
-        let signatures = signatures_for_id(id, langs);
-        if signatures.len() > 1 {
-            mismatched_ids.insert(id.clone());
-            let sig_vals = signatures
-                .values()
-                .map(|v| format!("[{}]", v.join(", ")))
-                .collect::<Vec<_>>()
-                .join(" != ");
+        for contract in &default.messages {
+            let id = &contract.id;
+            let mut missing_in: Vec<String> = Vec::new();
+            let mut incompatible_in: Vec<String> = Vec::new();
 
-            messages.push(format!(
-                "Different signatures for message {id} in languages: {sig_vals}",
-            ));
-        }
-    }
-    (messages, mismatched_ids)
-}
+            for lang in &others {
+                match lang.messages.iter().find(|m| &m.id == id) {
+                    None => missing_in.push(lang.language_id.clone()),
+                    Some(msg) if !compatible(contract, msg) => {
+                        incompatible_in
+                            .push(format!("{} ({}:{})", lang.language_id, msg.file, msg.line));
+                    }
+                    Some(_) => {}
+                }
+            }
 
-fn signatures_for_id<'a>(id: &Id, langs: &'a [LangBundle]) -> HashMap<Signature<'a>, Vec<String>> {
-    let mut signatures: HashMap<Signature<'a>, Vec<String>> = HashMap::new();
-    for lang in langs {
-        for msg in &lang.messages {
-            if &msg.id == id {
-                signatures
-                    .entry((msg.variables.as_slice(), msg.elements.as_slice()))
-                    .or_default()
-                    .push(msg.trait_signature());
+            if !missing_in.is_empty() {
+                warnings.push(format!(
+                    "{}:{}: {id} is not generated — missing from locale(s): {}",
+                    contract.file,
+                    contract.line,
+                    missing_in.join(", "),
+                ));
+            } else if !incompatible_in.is_empty() {
+                warnings.push(format!(
+                    "{}:{}: {id} is not generated — incompatible variables or \
+                     elements in locale(s): {}",
+                    contract.file,
+                    contract.line,
+                    incompatible_in.join(", "),
+                ));
+            } else {
+                common.insert(id.clone());
             }
         }
+
+        warnings.extend(orphan_warnings(&others, default));
+        warnings.sort();
+
+        Self { common, warnings }
     }
-    signatures
 }
 
-fn common_message_ids(langs: &[LangBundle]) -> HashSet<Id> {
-    let mut lang_signatures = vec![];
+/// Warn about messages that exist in non-default locales but are absent from
+/// the default locale — they have no contract, so no accessor is generated.
+fn orphan_warnings(others: &[&LangBundle], default: &LangBundle) -> Vec<String> {
+    let default_ids: HashSet<&Id> = default.messages.iter().map(|m| &m.id).collect();
+    let mut orphans: HashMap<Id, Vec<String>> = HashMap::new();
 
-    for lang in langs {
-        lang_signatures.push(
-            lang.messages
-                .iter()
-                .map(|msg| msg.id.clone())
-                .collect::<HashSet<Id>>(),
-        );
-    }
-    let mut iter = lang_signatures.iter();
-    // Safe: `from_locales_folder` rejects an empty locales folder, and
-    // `Builder::load_one` always produces exactly one bundle.
-    let mut common = iter.next().expect("at least one language bundle").clone();
-
-    for other in iter {
-        common = common.intersection(other).cloned().collect();
-    }
-    common
-}
-
-fn missing_message_ids(common_ids: &HashSet<Id>, langs: &[LangBundle]) -> Vec<String> {
-    let mut not_present: HashMap<Id, Vec<String>> = HashMap::new();
-
-    for lang in langs {
+    for lang in others {
         for msg in &lang.messages {
-            if !common_ids.contains(&msg.id) {
-                not_present
+            if !default_ids.contains(&msg.id) {
+                orphans
                     .entry(msg.id.clone())
                     .or_default()
                     .push(lang.language_id.clone());
             }
         }
     }
-    not_present
+
+    orphans
         .into_iter()
-        .map(|(id, v)| format!("Missing {id} for languages: {}", v.join(", ")))
+        .map(|(id, mut langs)| {
+            langs.sort();
+            format!(
+                "{id} is not generated — present in locale(s) {} but missing from \
+                 the default locale '{}'",
+                langs.join(", "),
+                default.language_id,
+            )
+        })
         .collect()
+}
+
+/// Whether `other` (a non-default locale's message) is structurally compatible
+/// with the `contract` (the default locale's message of the same id).
+///
+/// The check is comment-independent: it uses `pattern_refs`, the raw
+/// `$variable`/`-term` references, never the per-locale comment annotations.
+fn compatible(contract: &Message, other: &Message) -> bool {
+    let args: HashSet<&str> = contract.variables.iter().map(|v| v.id.as_str()).collect();
+
+    if contract.elements.is_empty() {
+        // Plain message: every variable the other locale references must be a
+        // known contract argument. Extra args would be unfilled at runtime.
+        other
+            .pattern_refs
+            .iter()
+            .filter(|r| r.kind == RefKind::Variable)
+            .all(|r| args.contains(r.name.as_str()))
+    } else {
+        // Element message: the element markers must line up exactly so that
+        // `msg_segments` splits the other locale's pattern into the same slots.
+        let element_names: HashSet<&str> =
+            contract.elements.iter().map(|e| e.name.as_str()).collect();
+
+        let contract_elems: Vec<(&str, ElementKind)> = contract
+            .elements
+            .iter()
+            .map(|e| (e.name.as_str(), e.kind))
+            .collect();
+        let other_elems: Vec<(&str, ElementKind)> = other
+            .pattern_refs
+            .iter()
+            .filter(|r| element_names.contains(r.name.as_str()))
+            .map(|r| (r.name.as_str(), element_kind(r.kind)))
+            .collect();
+        if contract_elems != other_elems {
+            return false;
+        }
+
+        // Non-element variables must still be known contract arguments.
+        other
+            .pattern_refs
+            .iter()
+            .filter(|r| r.kind == RefKind::Variable && !element_names.contains(r.name.as_str()))
+            .all(|r| args.contains(r.name.as_str()))
+    }
+}
+
+fn element_kind(kind: RefKind) -> ElementKind {
+    match kind {
+        RefKind::Variable => ElementKind::Variable,
+        RefKind::Term => ElementKind::Term,
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ mod tests;
 
 #[cfg(any(doc, feature = "build"))]
 pub use build::{
-    BuildError, BuildOptions, FtlOutputOptions, build_from_locales_folder,
+    BuildError, BuildOptions, FtlOutputOptions, LintLevel, build_from_locales_folder,
     try_build_from_locales_folder,
 };
 

--- a/src/tests/ast/attrib_only.rs
+++ b/src/tests/ast/attrib_only.rs
@@ -68,19 +68,28 @@ fn ast_use() {
 #[test]
 fn typed() {
     let resource = parser::parse(FTL).expect("Failed to parse an FTL resource.");
-    let message = resource.first_message();
+    let message = resource.first_message(FTL);
 
     println!("{:#?}", message);
     assert_eq!(
         message,
         Message {
-            comment: vec![],
+            // The message has no value of its own, so its comment is carried
+            // on the first attribute (so the linter can still inspect it).
+            comment: vec!["This is a message comment".to_string()],
             id: Id::new_attr("hello", "tooltip"),
             variables: vec![Variable {
                 id: "userName".to_string(),
                 typ: VarType::Any
             }],
             elements: vec![],
+            pattern_refs: vec![Ref {
+                name: "userName".to_string(),
+                kind: RefKind::Variable,
+            }],
+            file: String::new(),
+            line: 0,
+            comment_line: 0,
         }
     );
 }

--- a/src/tests/ast/mod.rs
+++ b/src/tests/ast/mod.rs
@@ -30,22 +30,25 @@ fn load_bundle() {
 }
 
 trait AstResourceExt {
-    fn first_message(&self) -> Message;
-    fn two_messages(&self) -> [Message; 2];
+    fn first_message(&self, src: &str) -> Message;
+    fn two_messages(&self, src: &str) -> [Message; 2];
 }
 
 impl AstResourceExt for ast::Resource<&str> {
-    fn first_message(&self) -> Message {
+    fn first_message(&self, src: &str) -> Message {
         match &self.body[0] {
-            ast::Entry::Message(message) => Message::parse(message).into_iter().next().unwrap(),
+            ast::Entry::Message(message) => Message::parse(message, src, "test.ftl")
+                .into_iter()
+                .next()
+                .unwrap(),
             _ => panic!("Expected a message."),
         }
     }
 
-    fn two_messages(&self) -> [Message; 2] {
+    fn two_messages(&self, src: &str) -> [Message; 2] {
         match &self.body[0] {
             ast::Entry::Message(message) => {
-                let msgs = Message::parse(message);
+                let msgs = Message::parse(message, src, "test.ftl");
                 assert_eq!(msgs.len(), 2);
                 msgs.try_into().unwrap()
             }

--- a/src/tests/ast/msg_element.rs
+++ b/src/tests/ast/msg_element.rs
@@ -19,7 +19,7 @@ calendar-sync-description =
 #[test]
 fn typed() {
     let resource = parser::parse(FTL).expect("Failed to parse an FTL resource.");
-    let message = resource.first_message();
+    let message = resource.first_message(FTL);
 
     println!("{message:#?}");
     assert_eq!(
@@ -53,6 +53,28 @@ fn typed() {
                     kind: ElementKind::Term,
                 },
             ],
+            // Every placeable, comment-independent and in document order.
+            pattern_refs: vec![
+                Ref {
+                    name: "num".to_string(),
+                    kind: RefKind::Variable,
+                },
+                Ref {
+                    name: "provider".to_string(),
+                    kind: RefKind::Variable,
+                },
+                Ref {
+                    name: "icon".to_string(),
+                    kind: RefKind::Variable,
+                },
+                Ref {
+                    name: "privacy-link".to_string(),
+                    kind: RefKind::Term,
+                },
+            ],
+            file: String::new(),
+            line: 0,
+            comment_line: 0,
         }
     );
 }

--- a/src/tests/ast/msg_number.rs
+++ b/src/tests/ast/msg_number.rs
@@ -65,7 +65,7 @@ fn ast_use() {
 #[test]
 fn typed() {
     let resource = parser::parse(FTL).expect("Failed to parse an FTL resource.");
-    let message = resource.first_message();
+    let message = resource.first_message(FTL);
 
     println!("{:#?}", message);
     assert_eq!(
@@ -78,6 +78,13 @@ fn typed() {
                 typ: VarType::Number,
             }],
             elements: vec![],
+            pattern_refs: vec![Ref {
+                name: "duration".to_string(),
+                kind: RefKind::Variable,
+            }],
+            file: String::new(),
+            line: 0,
+            comment_line: 0,
         }
     );
 }

--- a/src/tests/ast/msg_number_fn.rs
+++ b/src/tests/ast/msg_number_fn.rs
@@ -50,7 +50,7 @@ fn ast() {
 #[test]
 fn typed() {
     let resource = parser::parse(FTL).expect("Failed to parse an FTL resource.");
-    let message = resource.first_message();
+    let message = resource.first_message(FTL);
 
     println!("{message:#?}");
     assert_eq!(
@@ -63,6 +63,13 @@ fn typed() {
                 typ: VarType::Number,
             }],
             elements: vec![],
+            pattern_refs: vec![Ref {
+                name: "ratio".to_string(),
+                kind: RefKind::Variable,
+            }],
+            file: String::new(),
+            line: 0,
+            comment_line: 0,
         }
     );
 }
@@ -87,9 +94,13 @@ your-rank = { NUMBER($pos, type: "ordinal") ->
 }
 "#;
     let resource = parser::parse(ftl).expect("Failed to parse an FTL resource.");
-    let message = resource.first_message();
+    let message = resource.first_message(ftl);
 
     println!("{message:#?}");
+    let pos_ref = || Ref {
+        name: "pos".to_string(),
+        kind: RefKind::Variable,
+    };
     assert_eq!(
         message,
         Message {
@@ -100,6 +111,11 @@ your-rank = { NUMBER($pos, type: "ordinal") ->
                 typ: VarType::Number,
             }],
             elements: vec![],
+            // `$pos` in the selector and in each of the four variant bodies.
+            pattern_refs: vec![pos_ref(), pos_ref(), pos_ref(), pos_ref(), pos_ref(),],
+            file: String::new(),
+            line: 0,
+            comment_line: 0,
         }
     );
 }
@@ -115,7 +131,7 @@ status = { $state ->
 }
 "#;
     let resource = parser::parse(ftl).expect("Failed to parse an FTL resource.");
-    let message = resource.first_message();
+    let message = resource.first_message(ftl);
 
     println!("{message:#?}");
     assert_eq!(
@@ -134,6 +150,19 @@ status = { $state ->
                 },
             ],
             elements: vec![],
+            pattern_refs: vec![
+                Ref {
+                    name: "state".to_string(),
+                    kind: RefKind::Variable,
+                },
+                Ref {
+                    name: "detail".to_string(),
+                    kind: RefKind::Variable,
+                },
+            ],
+            file: String::new(),
+            line: 0,
+            comment_line: 0,
         }
     );
 }

--- a/src/tests/ast/msg_select.rs
+++ b/src/tests/ast/msg_select.rs
@@ -76,7 +76,7 @@ fn ast_use() {
 #[test]
 fn typed() {
     let resource = parser::parse(FTL).expect("Failed to parse an FTL resource.");
-    let message = resource.first_message();
+    let message = resource.first_message(FTL);
 
     println!("{:#?}", message);
     assert_eq!(
@@ -89,6 +89,13 @@ fn typed() {
                 typ: VarType::Any,
             }],
             elements: vec![],
+            pattern_refs: vec![Ref {
+                name: "var".to_string(),
+                kind: RefKind::Variable,
+            }],
+            file: String::new(),
+            line: 0,
+            comment_line: 0,
         }
     );
 }

--- a/src/tests/ast/msg_select_num.rs
+++ b/src/tests/ast/msg_select_num.rs
@@ -89,7 +89,7 @@ fn ast_use() {
 #[test]
 fn typed() {
     let resource = parser::parse(FTL).expect("Failed to parse an FTL resource.");
-    let message = resource.first_message();
+    let message = resource.first_message(FTL);
 
     println!("{:#?}", message);
     assert_eq!(
@@ -102,6 +102,19 @@ fn typed() {
                 typ: VarType::Number,
             }],
             elements: vec![],
+            pattern_refs: vec![
+                Ref {
+                    name: "num".to_string(),
+                    kind: RefKind::Variable,
+                },
+                Ref {
+                    name: "num".to_string(),
+                    kind: RefKind::Variable,
+                },
+            ],
+            file: String::new(),
+            line: 0,
+            comment_line: 0,
         }
     );
 }

--- a/src/tests/ast/msg_string.rs
+++ b/src/tests/ast/msg_string.rs
@@ -60,7 +60,7 @@ fn ast_use() {
 #[test]
 fn typed() {
     let resource = parser::parse(FTL).expect("Failed to parse an FTL resource.");
-    let message = resource.first_message();
+    let message = resource.first_message(FTL);
 
     println!("{:#?}", message);
     assert_eq!(
@@ -73,6 +73,13 @@ fn typed() {
                 typ: VarType::String,
             }],
             elements: vec![],
+            pattern_refs: vec![Ref {
+                name: "name".to_string(),
+                kind: RefKind::Variable,
+            }],
+            file: String::new(),
+            line: 0,
+            comment_line: 0,
         }
     );
 }

--- a/src/tests/ast/msg_text.rs
+++ b/src/tests/ast/msg_text.rs
@@ -50,7 +50,7 @@ fn ast_use() {
 #[test]
 fn typed() {
     let resource = parser::parse(FTL).expect("Failed to parse an FTL resource.");
-    let message = resource.first_message();
+    let message = resource.first_message(FTL);
 
     println!("{:#?}", message);
     assert_eq!(
@@ -60,6 +60,10 @@ fn typed() {
             comment: vec![],
             variables: vec![],
             elements: vec![],
+            pattern_refs: vec![],
+            file: String::new(),
+            line: 0,
+            comment_line: 0,
         }
     );
 }

--- a/src/tests/ast/msg_with_attrib.rs
+++ b/src/tests/ast/msg_with_attrib.rs
@@ -76,7 +76,7 @@ fn ast_use() {
 #[test]
 fn typed() {
     let resource = parser::parse(FTL).expect("Failed to parse an FTL resource.");
-    let [message, attr] = resource.two_messages();
+    let [message, attr] = resource.two_messages(FTL);
 
     println!("{:#?}", message);
     assert_eq!(
@@ -86,6 +86,10 @@ fn typed() {
             id: Id::new_msg("hello"),
             variables: vec![],
             elements: vec![],
+            pattern_refs: vec![],
+            file: String::new(),
+            line: 0,
+            comment_line: 0,
         }
     );
     println!("{:#?}", attr);
@@ -99,6 +103,13 @@ fn typed() {
                 typ: VarType::Any
             }],
             elements: vec![],
+            pattern_refs: vec![Ref {
+                name: "userName".to_string(),
+                kind: RefKind::Variable,
+            }],
+            file: String::new(),
+            line: 0,
+            comment_line: 0,
         }
     );
 }

--- a/src/tests/ast/msg_with_var.rs
+++ b/src/tests/ast/msg_with_var.rs
@@ -56,7 +56,7 @@ fn ast_use() {
 #[test]
 fn typed() {
     let resource = parser::parse(FTL).expect("Failed to parse an FTL resource.");
-    let message = resource.first_message();
+    let message = resource.first_message(FTL);
 
     println!("{:#?}", message);
     assert_eq!(
@@ -69,6 +69,13 @@ fn typed() {
                 typ: VarType::Any
             }],
             elements: vec![],
+            pattern_refs: vec![Ref {
+                name: "first-name".to_string(),
+                kind: RefKind::Variable,
+            }],
+            file: String::new(),
+            line: 0,
+            comment_line: 0,
         }
     );
 }

--- a/src/tests/ast/res_msg_text.rs
+++ b/src/tests/ast/res_msg_text.rs
@@ -34,7 +34,7 @@ fn ast() {
 #[test]
 fn typed() {
     let resource = parser::parse(FTL).expect("Failed to parse an FTL resource.");
-    let message = resource.first_message();
+    let message = resource.first_message(FTL);
 
     println!("{:#?}", message);
     assert_eq!(
@@ -44,6 +44,10 @@ fn typed() {
             comment: vec![],
             variables: vec![],
             elements: vec![],
+            pattern_refs: vec![],
+            file: String::new(),
+            line: 0,
+            comment_line: 0,
         }
     );
 }

--- a/src/tests/gen/attrib_only_gen.rs
+++ b/src/tests/gen/attrib_only_gen.rs
@@ -117,6 +117,7 @@ impl L10nLanguage {
         Ok(Self(L10nBundle::new(lang, bytes)?))
     }
 
+    /// This is a message comment
     pub fn msg_hello_tooltip<'a, F0: Into<FluentValue<'a>>>(&self, user_name: F0) -> String {
         let mut args = FluentArgs::new();
         args.set("userName", user_name);

--- a/src/tests/lint.rs
+++ b/src/tests/lint.rs
@@ -363,6 +363,24 @@ fn a_parse_error_names_the_file_and_line() {
 }
 
 #[test]
+fn a_parse_error_carries_a_human_readable_message() {
+    // fluent-syntax's own `Display` message, not the terse `Debug` enum form.
+    let err = LangBundle::from_ftl("broken { $x }\n", "bad.ftl", "en", true)
+        .expect_err("a message without `=` must fail to parse");
+    match &err {
+        BuildError::FtlParse { errors, .. } => {
+            assert_eq!(errors.len(), 1, "{errors:?}");
+            assert!(
+                errors[0].contains("Expected a token"),
+                "expected a readable message, got {:?}",
+                errors[0],
+            );
+        }
+        other => panic!("expected FtlParse, got {other:?}"),
+    }
+}
+
+#[test]
 fn a_parse_error_in_a_non_ascii_file_does_not_panic() {
     // Malformed line preceded by multi-byte UTF-8 — the error byte offset must
     // not be used to slice the source at a non-char-boundary.

--- a/src/tests/lint.rs
+++ b/src/tests/lint.rs
@@ -466,3 +466,109 @@ fn a_deny_failure_message_does_not_mention_strict_mode() {
     );
     assert!(display.contains("lint error"), "{display}");
 }
+
+// ----------------------------------------------------------------------------
+// Errors are collected across files, not reported one rebuild at a time.
+// ----------------------------------------------------------------------------
+
+#[test]
+fn parse_errors_in_several_files_are_reported_together() {
+    let dir = "target/test-lint/multi-parse-err";
+    let en = format!("{dir}/locales/en");
+    std::fs::create_dir_all(&en).unwrap();
+    std::fs::write(format!("{en}/a.ftl"), "broken { $x }\n").unwrap();
+    std::fs::write(format!("{en}/b.ftl"), "ok = fine\nalso-broken { $y }\n").unwrap();
+
+    let opts = BuildOptions::default()
+        .with_locales_folder(&format!("{dir}/locales"))
+        .with_output_file_path(&format!("{dir}/l10n.rs"))
+        .with_ftl_output(FtlOutputOptions::SingleFile {
+            output_ftl_file: format!("{dir}/t.ftl"),
+            compressor: None,
+        });
+
+    let err = Builder::load(opts)
+        .err()
+        .expect("two malformed files must fail the build");
+    let display = err.to_string();
+    assert!(
+        display.contains("a.ftl") && display.contains("b.ftl"),
+        "the report must name both files: {display}"
+    );
+    match err {
+        BuildError::Multiple(errors) => {
+            assert_eq!(errors.len(), 2, "{errors:?}");
+            assert!(
+                errors
+                    .iter()
+                    .all(|e| matches!(e, BuildError::FtlParse { .. })),
+                "{errors:?}",
+            );
+        }
+        other => panic!("expected BuildError::Multiple, got {other:?}"),
+    }
+}
+
+#[test]
+fn every_duplicate_key_is_reported() {
+    // Two distinct keys are each defined twice — all four-into-two duplicates
+    // must be reported, not just the first.
+    let err = LangBundle::from_ftl(
+        "hello = One\nhello = Two\nbye = A\nbye = B\n",
+        "dup.ftl",
+        "en",
+        true,
+    )
+    .expect_err("duplicate keys must fail");
+    match err {
+        BuildError::Multiple(errors) => {
+            assert_eq!(errors.len(), 2, "{errors:?}");
+            assert!(
+                errors
+                    .iter()
+                    .all(|e| matches!(e, BuildError::DuplicateKey { .. })),
+                "{errors:?}",
+            );
+        }
+        other => panic!("expected BuildError::Multiple, got {other:?}"),
+    }
+}
+
+#[test]
+fn a_parse_error_and_a_duplicate_key_are_reported_together() {
+    let dir = "target/test-lint/mixed-errors";
+    let en = format!("{dir}/locales/en");
+    std::fs::create_dir_all(&en).unwrap();
+    std::fs::write(format!("{en}/a.ftl"), "broken { $x }\n").unwrap();
+    std::fs::write(format!("{en}/b.ftl"), "dup = One\ndup = Two\n").unwrap();
+
+    let opts = BuildOptions::default()
+        .with_locales_folder(&format!("{dir}/locales"))
+        .with_output_file_path(&format!("{dir}/l10n.rs"))
+        .with_ftl_output(FtlOutputOptions::SingleFile {
+            output_ftl_file: format!("{dir}/t.ftl"),
+            compressor: None,
+        });
+
+    let err = Builder::load(opts)
+        .err()
+        .expect("both problems must fail the build");
+    match err {
+        BuildError::Multiple(errors) => {
+            assert_eq!(errors.len(), 2, "{errors:?}");
+            assert!(
+                errors
+                    .iter()
+                    .any(|e| matches!(e, BuildError::FtlParse { .. })),
+                "{errors:?}",
+            );
+            assert!(
+                errors
+                    .iter()
+                    .any(|e| matches!(e, BuildError::DuplicateKey { .. })),
+                "{errors:?}",
+            );
+        }
+        other => panic!("expected BuildError::Multiple, got {other:?}"),
+    }
+}

--- a/src/tests/lint.rs
+++ b/src/tests/lint.rs
@@ -1,0 +1,468 @@
+//! Tests for comment linting, strict mode, the contract-based cross-locale
+//! analysis, and the file/line detail of build errors.
+
+use crate::build::typed::Id;
+use crate::build::{Analyzed, Builder, LangBundle, lint};
+use crate::{BuildError, BuildOptions, FtlOutputOptions, LintLevel};
+
+fn bundle(ftl: &str, file: &str, lang: &str) -> LangBundle {
+    LangBundle::from_ftl(ftl, file, lang, true).expect("ftl should parse")
+}
+
+/// Run the linter over a single default-locale bundle.
+fn lints_of(ftl: &str) -> lint::Lints {
+    let langs = vec![bundle(ftl, "main.ftl", "en")];
+    let analyzed = Analyzed::from(&langs, &langs[0]);
+    lint::check(&langs, &langs[0], &analyzed.common)
+}
+
+/// Run the full build of a single `en` locale at the given lint level.
+fn build_at(dir: &str, level: LintLevel, ftl: &str) -> Result<(), BuildError> {
+    let dir = format!("target/test-lint/{dir}");
+    std::fs::create_dir_all(&dir).unwrap();
+    let opts = BuildOptions::default()
+        .with_lint_level(level)
+        .without_format()
+        .with_output_file_path(&format!("{dir}/l10n.rs"))
+        .with_ftl_output(FtlOutputOptions::SingleFile {
+            output_ftl_file: format!("{dir}/t.ftl"),
+            compressor: None,
+        });
+    Builder::load_one(opts, "test", "en", ftl)?.generate()
+}
+
+// ----------------------------------------------------------------------------
+// L1–L3: comment mistakes in the default locale.
+// ----------------------------------------------------------------------------
+
+#[test]
+fn l1_unrecognized_keyword() {
+    let lints = lints_of("# $count (Numbr) - how many\nfoo = You have { $count }\n");
+    assert_eq!(
+        lints.mistakes,
+        [
+            "main.ftl:1: unrecognized type annotation '(Numbr)' for $count — \
+          expected (String), (Number) or (Element)"
+        ],
+    );
+}
+
+#[test]
+fn l2_annotation_of_missing_variable() {
+    let lints = lints_of("# $nme (String) - the name\nhello = Hello { $name }\n");
+    assert_eq!(
+        lints.mistakes,
+        [
+            "main.ftl:1: comment annotates $nme but message 'hello' references no \
+          such variable"
+        ],
+    );
+}
+
+#[test]
+fn l3_detached_annotation_comment() {
+    // The blank line detaches the comment from `hello`.
+    let lints = lints_of("# $name (String) - the name\n\nhello = Hello { $name }\n");
+    assert_eq!(
+        lints.mistakes,
+        [
+            "main.ftl:1: type annotation '$name (String)' is detached from its \
+          message by a blank line and has no effect"
+        ],
+    );
+}
+
+#[test]
+fn a_correct_comment_produces_no_mistakes() {
+    let lints = lints_of("# $name (String) - the name\nhello = Hello { $name }\n");
+    assert!(lints.mistakes.is_empty(), "{:?}", lints.mistakes);
+}
+
+// ----------------------------------------------------------------------------
+// L5: annotations in a non-default locale have no effect.
+// ----------------------------------------------------------------------------
+
+#[test]
+fn l5_annotation_in_non_default_locale() {
+    let langs = vec![
+        bundle("hello = Hello { $name }\n", "en.ftl", "en"),
+        bundle(
+            "# $name (String) - le nom\nhello = Bonjour { $name }\n",
+            "fr.ftl",
+            "fr",
+        ),
+    ];
+    let analyzed = Analyzed::from(&langs, &langs[0]);
+    let lints = lint::check(&langs, &langs[0], &analyzed.common);
+
+    assert!(lints.mistakes.is_empty(), "{:?}", lints.mistakes);
+    assert_eq!(
+        lints.ineffective,
+        [
+            "fr.ftl:1: type annotation '$name (String)' in non-default locale 'fr' \
+          has no effect — type comments only apply to the default locale"
+        ],
+    );
+}
+
+// ----------------------------------------------------------------------------
+// Strict mode.
+// ----------------------------------------------------------------------------
+
+#[test]
+fn strict_rejects_an_untyped_variable() {
+    let err = build_at("untyped", LintLevel::Strict, "hello = Hello { $name }\n")
+        .expect_err("an untyped variable must fail strict mode");
+    match err {
+        BuildError::Lint { messages } => assert_eq!(
+            messages,
+            [
+                "test:1: variable $name in message 'hello' has no type — add a \
+              '# $name (String)' or '# $name (Number)' comment"
+            ],
+        ),
+        other => panic!("expected BuildError::Lint, got {other:?}"),
+    }
+}
+
+#[test]
+fn strict_accepts_a_fully_typed_message() {
+    build_at(
+        "typed",
+        LintLevel::Strict,
+        "# $name (String) - the name\nhello = Hello { $name }\n",
+    )
+    .expect("a fully typed message must pass strict mode");
+}
+
+#[test]
+fn strict_promotes_comment_mistakes_to_errors() {
+    let err = build_at("typo", LintLevel::Strict, "# $x (Strng)\nhi = Hi { $x }\n")
+        .expect_err("a typo'd keyword must fail strict mode");
+    assert!(matches!(err, BuildError::Lint { .. }), "{err:?}");
+}
+
+#[test]
+fn lint_level_off_silences_everything() {
+    // A typo'd keyword and an untyped variable — both ignored when Off.
+    build_at("off", LintLevel::Off, "# $x (Strng)\nhi = Hi { $x }\n")
+        .expect("LintLevel::Off must not fail the build");
+}
+
+#[test]
+fn warn_level_does_not_fail_the_build() {
+    // The default level: a typo is only a warning, the build still succeeds.
+    build_at("warn", LintLevel::Warn, "# $x (Strng)\nhi = Hi { $x }\n")
+        .expect("LintLevel::Warn must not fail the build");
+}
+
+#[test]
+fn deny_fails_on_a_comment_mistake() {
+    let err = build_at(
+        "deny-typo",
+        LintLevel::Deny,
+        "# $x (Strng)\nhi = Hi { $x }\n",
+    )
+    .expect_err("Deny must fail on a comment mistake");
+    assert!(matches!(err, BuildError::Lint { .. }), "{err:?}");
+}
+
+#[test]
+fn deny_allows_an_untyped_variable() {
+    // `$name` is untyped — allowed under Deny, unlike Strict.
+    build_at("deny-untyped", LintLevel::Deny, "hello = Hello { $name }\n")
+        .expect("Deny must allow an untyped variable");
+}
+
+// ----------------------------------------------------------------------------
+// Source locations: the file and line in a diagnostic must be exact, including
+// for an annotation partway down a multi-line comment block.
+// ----------------------------------------------------------------------------
+
+#[test]
+fn a_diagnostic_points_at_the_right_line_of_a_multi_line_comment() {
+    // line 1: (blank)
+    // line 2: # greeting shown on login   <- prose, not an annotation
+    // line 3: # $nam (String) - the name  <- the mistake (typo'd variable)
+    // line 4: # $count (Number) - count
+    // line 5: welcome = ...
+    let ftl = "\n# greeting shown on login\n# $nam (String) - the name\n\
+               # $count (Number) - count\nwelcome = Hi { $name }, { $count } new\n";
+    let lints = lints_of(ftl);
+    assert_eq!(
+        lints.mistakes,
+        [
+            "main.ftl:3: comment annotates $nam but message 'welcome' references no \
+          such variable"
+        ],
+        "the annotation is the 2nd comment line, so it must be reported at line 3",
+    );
+}
+
+#[test]
+fn the_untyped_error_points_at_the_message_line() {
+    // The leading comment is detached by a blank line, so `hello` (line 4) has
+    // no comment and `$name` is untyped.
+    let err = build_at(
+        "untyped-line",
+        LintLevel::Strict,
+        "# a comment\n# another\n\nhello = Hello { $name }\n",
+    )
+    .expect_err("an untyped variable must fail strict mode");
+    match err {
+        BuildError::Lint { messages } => assert_eq!(
+            messages,
+            [
+                "test:4: variable $name in message 'hello' has no type — add a \
+              '# $name (String)' or '# $name (Number)' comment"
+            ],
+        ),
+        other => panic!("expected BuildError::Lint, got {other:?}"),
+    }
+}
+
+#[test]
+fn diagnostics_are_per_resource_file_in_a_multi_resource_locale() {
+    // A locale folder with two `.ftl` files. The mistake is on line 2 of the
+    // *second* file — its diagnostic must name that file and that line, not an
+    // offset into the concatenated bundle.
+    let dir = "target/test-lint/multi-resource";
+    let en = format!("{dir}/locales/en");
+    std::fs::create_dir_all(&en).unwrap();
+    std::fs::write(format!("{en}/a.ftl"), "first = First message\n").unwrap();
+    std::fs::write(
+        format!("{en}/b.ftl"),
+        "greeting = Hi\nwelcome = Hello { $name }\n",
+    )
+    .unwrap();
+
+    let opts = BuildOptions::default()
+        .with_lint_level(LintLevel::Strict)
+        .without_format()
+        .with_locales_folder(&format!("{dir}/locales"))
+        .with_output_file_path(&format!("{dir}/l10n.rs"))
+        .with_ftl_output(FtlOutputOptions::SingleFile {
+            output_ftl_file: format!("{dir}/t.ftl"),
+            compressor: None,
+        });
+
+    let err = Builder::load(opts)
+        .unwrap()
+        .generate()
+        .expect_err("the untyped $name in b.ftl must fail strict mode");
+    match err {
+        BuildError::Lint { messages } => {
+            assert_eq!(messages.len(), 1, "{messages:?}");
+            let m = &messages[0];
+            assert!(m.contains("b.ftl:2:"), "must name b.ftl line 2: {m}");
+            assert!(m.contains("variable $name in message 'welcome'"), "{m}");
+        }
+        other => panic!("expected BuildError::Lint, got {other:?}"),
+    }
+}
+
+// ----------------------------------------------------------------------------
+// Contract-based cross-locale analysis.
+// ----------------------------------------------------------------------------
+
+#[test]
+fn a_type_difference_across_locales_is_not_a_mismatch() {
+    // Only the default locale types `$name`; the message is still generated.
+    let langs = vec![
+        bundle(
+            "# $name (String) - name\nhello = Hello { $name }\n",
+            "en.ftl",
+            "en",
+        ),
+        bundle("hello = Bonjour { $name }\n", "fr.ftl", "fr"),
+    ];
+    let analyzed = Analyzed::from(&langs, &langs[0]);
+    assert!(analyzed.warnings.is_empty(), "{:?}", analyzed.warnings);
+    assert!(analyzed.common.contains(&Id::new_msg("hello")));
+}
+
+#[test]
+fn an_extra_variable_in_another_locale_drops_the_message() {
+    let langs = vec![
+        bundle("hello = Hello { $name }\n", "en.ftl", "en"),
+        bundle("hello = Bonjour { $name } et { $extra }\n", "fr.ftl", "fr"),
+    ];
+    let analyzed = Analyzed::from(&langs, &langs[0]);
+    assert!(!analyzed.common.contains(&Id::new_msg("hello")));
+    assert_eq!(
+        analyzed.warnings,
+        [
+            "en.ftl:1: message 'hello' is not generated — incompatible variables or \
+          elements in locale(s): fr (fr.ftl:1)"
+        ],
+    );
+}
+
+#[test]
+fn a_message_missing_from_the_default_locale_is_reported() {
+    let langs = vec![
+        bundle("hello = Hello\n", "en.ftl", "en"),
+        bundle("hello = Bonjour\nbye = Au revoir\n", "fr.ftl", "fr"),
+    ];
+    let analyzed = Analyzed::from(&langs, &langs[0]);
+    assert!(analyzed.common.contains(&Id::new_msg("hello")));
+    assert_eq!(
+        analyzed.warnings,
+        [
+            "message 'bye' is not generated — present in locale(s) fr but missing \
+          from the default locale 'en'"
+        ],
+    );
+}
+
+#[test]
+fn a_message_missing_from_another_locale_is_reported() {
+    let langs = vec![
+        bundle("hello = Hello\nbye = Bye\n", "en.ftl", "en"),
+        bundle("hello = Bonjour\n", "fr.ftl", "fr"),
+    ];
+    let analyzed = Analyzed::from(&langs, &langs[0]);
+    assert!(analyzed.common.contains(&Id::new_msg("hello")));
+    assert!(!analyzed.common.contains(&Id::new_msg("bye")));
+    assert_eq!(
+        analyzed.warnings,
+        ["en.ftl:2: message 'bye' is not generated — missing from locale(s): fr"],
+    );
+}
+
+// ----------------------------------------------------------------------------
+// Build errors name the file (and line) of the problem.
+// ----------------------------------------------------------------------------
+
+#[test]
+fn missing_default_language_is_an_error() {
+    let err = Builder::load_one(BuildOptions::default(), "test", "fr", "hello = Bonjour\n")
+        .unwrap()
+        .generate()
+        .expect_err("a missing default language must fail the build");
+    match &err {
+        BuildError::DefaultLanguageNotFound { language, .. } => assert_eq!(language, "en"),
+        other => panic!("expected DefaultLanguageNotFound, got {other:?}"),
+    }
+    assert!(err.to_string().contains("'en'"), "{err}");
+}
+
+#[test]
+fn a_parse_error_names_the_file_and_line() {
+    let err = LangBundle::from_ftl("ok = fine\nbroken { $x }\n", "bad.ftl", "en", true)
+        .expect_err("malformed ftl must fail to parse");
+    match &err {
+        BuildError::FtlParse { path, errors } => {
+            assert!(path.ends_with("bad.ftl"), "{path:?}");
+            assert!(!errors.is_empty());
+            assert!(errors[0].starts_with("line "), "{:?}", errors[0]);
+        }
+        other => panic!("expected FtlParse, got {other:?}"),
+    }
+    assert!(err.to_string().contains("bad.ftl"), "{err}");
+}
+
+#[test]
+fn a_parse_error_in_a_non_ascii_file_does_not_panic() {
+    // Malformed line preceded by multi-byte UTF-8 — the error byte offset must
+    // not be used to slice the source at a non-char-boundary.
+    let err = LangBundle::from_ftl(
+        "grüße = Hallo schöne Welt café\nbroken { $x }\n",
+        "bad.ftl",
+        "en",
+        true,
+    )
+    .expect_err("malformed ftl must fail to parse");
+    assert!(matches!(err, BuildError::FtlParse { .. }), "{err:?}");
+}
+
+// ----------------------------------------------------------------------------
+// Regression tests for review findings.
+// ----------------------------------------------------------------------------
+
+#[test]
+fn a_prose_parenthetical_is_not_flagged_as_a_typo() {
+    // `(required)` is ordinary prose, not a botched type annotation — the
+    // linter must leave it alone (it would otherwise fail Deny/Strict builds).
+    let lints = lints_of("# $name (required) - the user's name\nhello = Hi { $name }\n");
+    assert!(lints.mistakes.is_empty(), "{:?}", lints.mistakes);
+}
+
+#[test]
+fn a_near_miss_keyword_is_still_flagged() {
+    // `(Strng)` is one edit away from `(String)` — a real typo, still caught.
+    let lints = lints_of("# $name (Strng)\nhello = Hi { $name }\n");
+    assert_eq!(lints.mistakes.len(), 1, "{:?}", lints.mistakes);
+    assert!(
+        lints.mistakes[0].contains("unrecognized type annotation '(Strng)'"),
+        "{:?}",
+        lints.mistakes,
+    );
+}
+
+#[test]
+fn an_attribute_only_message_comment_is_linted() {
+    // `hello` has no value, only a `.tooltip` attribute. Its comment must
+    // still be linted — here, a typo'd keyword.
+    let lints = lints_of("# $name (Strng)\nhello =\n    .tooltip = Hi { $name }\n");
+    assert_eq!(lints.mistakes.len(), 1, "{:?}", lints.mistakes);
+    assert!(
+        lints.mistakes[0].contains("unrecognized type annotation '(Strng)'"),
+        "{:?}",
+        lints.mistakes,
+    );
+}
+
+#[test]
+fn strict_allows_an_element_variable_reused_in_an_attribute() {
+    // `$icon` is annotated `(Element)`; it is also referenced in an attribute,
+    // where it stays a runtime argument. Strict must not demand a type for it.
+    build_at(
+        "element-attr",
+        LintLevel::Strict,
+        "# $icon (Element) - an injected icon\n\
+         notice = Click { $icon } now\n    .aria = icon { $icon }\n",
+    )
+    .expect("an (Element) variable reused in an attribute must pass strict mode");
+}
+
+#[test]
+fn a_duplicate_key_generates_the_accessor_only_once() {
+    let dir = "target/test-lint/dup-accessor";
+    std::fs::create_dir_all(dir).unwrap();
+    let out = format!("{dir}/l10n.rs");
+    let opts = BuildOptions::default()
+        .with_allow_duplicate_keys()
+        .without_format()
+        .with_output_file_path(&out)
+        .with_ftl_output(FtlOutputOptions::SingleFile {
+            output_ftl_file: format!("{dir}/t.ftl"),
+            compressor: None,
+        });
+    Builder::load_one(opts, "test", "en", "hello = One\nhello = Two\n")
+        .unwrap()
+        .generate()
+        .unwrap();
+    let generated = std::fs::read_to_string(&out).unwrap();
+    assert_eq!(
+        generated.matches("fn msg_hello").count(),
+        1,
+        "a duplicated key must still generate exactly one accessor",
+    );
+}
+
+#[test]
+fn a_deny_failure_message_does_not_mention_strict_mode() {
+    let err = build_at(
+        "deny-msg",
+        LintLevel::Deny,
+        "# $x (Strng)\nhi = Hi { $x }\n",
+    )
+    .expect_err("Deny must fail on a comment mistake");
+    let display = err.to_string();
+    assert!(
+        !display.contains("strict"),
+        "Deny message must not say strict: {display}"
+    );
+    assert!(display.contains("lint error"), "{display}");
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,6 +1,7 @@
 mod ast;
 mod complex;
 mod r#gen;
+mod lint;
 mod runtime;
 
 use std::fs;
@@ -183,6 +184,7 @@ fn test_duplicate_key_fails() {
         key,
         original,
         duplicate,
+        ..
     }) = &Builder::load(options)
     {
         assert_eq!(key, "hello-world");
@@ -213,11 +215,15 @@ fn test_duplicate_key_single_file_fails() {
     if let Err(BuildError::DuplicateKey {
         key,
         original,
+        original_line,
         duplicate,
+        duplicate_line,
     }) = &Builder::load_one(options, "test", "en", ftl)
     {
         assert_eq!(key, "hello-world");
         assert_eq!(original, duplicate);
+        assert_eq!(*original_line, 1);
+        assert_eq!(*duplicate_line, 2);
     } else {
         panic!("Expected a DuplicateKey error");
     }

--- a/src/tests/snapshots/fluent_typed__tests__attrib_only.snap
+++ b/src/tests/snapshots/fluent_typed__tests__attrib_only.snap
@@ -121,6 +121,7 @@ impl L10nLanguage {
         Ok(Self(L10nBundle::new(lang, bytes)?))
     }
 
+    /// This is a message comment
     pub fn msg_hello_tooltip<'a, F0: Into<FluentValue<'a>>>(&self, user_name: F0) -> String {
         let mut args = FluentArgs::new();
         args.set("userName", user_name);


### PR DESCRIPTION
## Summary

Turns the silent comment-handling footguns in fluent-typed into real diagnostics, and fixes the root cause behind them.

### Default-locale type sourcing

The `default_language` locale is now the **single source of truth** for every message's typed signature (variables, types, `(Element)` layout). Other locales are validated for *structural* compatibility but their type comments no longer affect output. This fixes the old behavior where a type comment present in only one locale produced a "signature mismatch" and the message was **silently dropped** from the generated API — effectively forcing translators to maintain Rust type metadata in every locale.

### Linting

Comment mistakes are now caught and reported with the `.ftl` **file and line** of each:

- a typo'd type keyword — `(Numbr)`, a near-miss of `String`/`Number`/`Element`;
- an annotation of a variable the message does not have — `# $nme` vs `$name`;
- a type-annotation comment detached from its message by a blank line;
- a type annotation in a non-default locale, where it has no effect.

A new **`LintLevel`** on `BuildOptions` (`with_lint_level`) controls enforcement:

| Level | Comment mistakes | Untyped variable |
|-------|------------------|------------------|
| `Off` | ignored | allowed |
| `Warn` (default) | `cargo::warning=` | allowed |
| `Deny` | hard error | allowed |
| `Strict` | hard error | hard error |

Ordinary prose in parentheses (`# $count (max 99)`) is **not** flagged — only near-miss typos of real keywords are.

### Clearer build errors

- `BuildError::FtlParse` now carries `{ path, errors }` with per-error line numbers (was an opaque `{:?}` dump).
- `BuildError::DuplicateKey` gained `original_line` / `duplicate_line`.
- New `BuildError::DefaultLanguageNotFound` and `BuildError::Lint`.

## Breaking changes

- Type / `(Element)` comments in non-default locales no longer affect output.
- `BuildError::FtlParse` is now a struct variant; `DuplicateKey` has new fields.
- `BuildOptions` gains a `lint_level` field (default `Warn`) — `BuildOptions::default()` users are unaffected.
- Generated `///` doc comments now always come from the default locale.

See `CHANGELOG.md` for the full list.

## Tests

93 tests pass (was 63 on `main`). New `src/tests/lint.rs` covers every lint, all four lint levels, the contract-based cross-locale analysis, source-location accuracy (including multi-line comments and multi-resource locales), and the file/line detail of build errors. `cargo clippy` / `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)