### PR TITLE
Make runtime L10n types Send + Sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.6.2
+
+### Changed
+- The runtime types `L10nBundle`, `L10nLanguageVec` and the generated
+  `L10nLanguage` are now `Send + Sync`, so loaded localizations can be shared
+  across threads (e.g. behind an `Arc` in shared web-server state). Internally
+  the bundle now uses fluent-bundle's concurrent (`Mutex`-based) memoizer.
+
+## 0.6.1
+
+### Added
+- `BuildError::TermMessageCollision` — a term and a message that share a bare
+  name (e.g. `-foo` and `foo`) collide in fluent-bundle's single-namespace
+  entry map and would otherwise crash at resource-load time. This is now caught
+  at build time and reported with the name and the file/line of both the term
+  and the message definition.
+
+### Changed
+- **Breaking:** `BuildError` is now `#[non_exhaustive]`. Downstream code that
+  matches it exhaustively must add a wildcard arm. This future-proofs the enum
+  so subsequent variant additions stay on patch releases.
+
 ## 0.6.0
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluent-typed"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 description = "Type-safe access to Fluent localization messages"
 keywords = ["fluent", "internationalization", "localization"]

--- a/src/l10n_bundle.rs
+++ b/src/l10n_bundle.rs
@@ -1,4 +1,5 @@
-use fluent_bundle::{FluentArgs, FluentBundle, FluentResource};
+use fluent_bundle::concurrent::FluentBundle;
+use fluent_bundle::{FluentArgs, FluentResource};
 use fluent_syntax::ast::{Expression, InlineExpression, Pattern, PatternElement};
 use unic_langid::LanguageIdentifier;
 
@@ -32,7 +33,7 @@ impl L10nBundle {
         let ftl = String::from_utf8(bytes.to_vec())
             .map_err(|e| format!("Could not read ftl string due to: {e}"))?;
         let lang_id: LanguageIdentifier = lang.as_ref().parse().map_err(|e| format!("{e:?}"))?;
-        let mut bundle = FluentBundle::new(vec![lang_id]);
+        let mut bundle = FluentBundle::new_concurrent(vec![lang_id]);
         bundle.set_use_isolating(use_isolating);
         // Register the FTL builtins (`NUMBER`, …). Without this, any message
         // using `{ NUMBER($x) }` fails to format and `msg`/`attr` return an

--- a/src/tests/runtime.rs
+++ b/src/tests/runtime.rs
@@ -5,6 +5,16 @@
 
 use crate::prelude::{FluentArgs, L10nBundle, L10nLanguageVec, Segment};
 
+#[test]
+fn runtime_types_are_send_and_sync() {
+    fn assert_send_sync<T: Send + Sync>() {}
+    // Guards against a future field addition silently dropping the auto traits.
+    // The generated `L10nLanguage` newtype lives outside this crate but inherits
+    // these from `L10nBundle`.
+    assert_send_sync::<L10nBundle>();
+    assert_send_sync::<L10nLanguageVec>();
+}
+
 const FTL: &str = r#"
 greeting = Hello world
 hello = Hi { $name }!


### PR DESCRIPTION
## What

Make the runtime localization types — `L10nBundle`, `L10nLanguageVec`, and the generated `L10nLanguage` newtype — `Send + Sync`, so a loaded localization can be shared across threads (e.g. behind an `Arc` in shared web-server state, a `OnceLock`, or sent across a task boundary).

## Why

Every field of `L10nBundle` was already `Send + Sync` **except** the embedded `fluent_bundle::FluentBundle<FluentResource>`, whose default memoizer (`intl_memoizer::IntlLangMemoizer`) is `Rc<RefCell<…>>`-based and therefore `!Send + !Sync`. That single field was the only blocker.

## How

`fluent-bundle` 0.16 ships a drop-in concurrent specialization, `fluent_bundle::concurrent::FluentBundle<R>`, backed by a `Mutex`-based memoizer that *is* `Send + Sync`, constructed with `new_concurrent()` instead of `new()`. Every formatting method the code already calls lives in the generic `impl<R, M>` block, so behavior is unchanged — the diff in `l10n_bundle.rs` is just the import and the constructor.

This is **not a breaking change**: the `bundle` field is private with no public accessor leaking the type, and generated code only ever constructs via `L10nBundle::new` / `L10nLanguageVec::load`. `L10nLanguage` is a generated `pub struct L10nLanguage(L10nBundle)` newtype, so it inherits the traits automatically with nothing to regenerate.

## Changes

- `src/l10n_bundle.rs` — switch to the concurrent bundle (`new_concurrent`)
- `src/tests/runtime.rs` — `runtime_types_are_send_and_sync` compile-checked regression guard
- `Cargo.toml` + `CHANGELOG.md` — bump to 0.6.2, document the change, and backfill the previously undocumented 0.6.1 entry (`TermMessageCollision` + `BuildError` `#[non_exhaustive]`)

## Verification

- `cargo test` — 100 unit tests + integration tests pass (the guard is the +1 over the previous 99)
- `cargo build --features build` and `cargo test --features langneg` — clean
- **Negative check:** reverting to the default bundle makes the build fail with `error[E0277]: RefCell<type_map::TypeMap> cannot be shared between threads safely`, chaining `IntlLangMemoizer → FluentBundle → L10nBundle`, "required by a bound in `assert_send_sync`" — confirming the guard actually guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)