### PR TITLE
Harden CI and prep packaging/docs for promotion

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: CI
 
 on:
   push:
@@ -10,12 +10,53 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  test:
+    name: Test (stable)
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v6
-      - name: Build
-        run: cargo build --verbose
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
       - name: Run tests
-        run: cargo test --verbose --features build,langneg
+        run: cargo test --features build,langneg --verbose
+
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --all-targets --features build,langneg -- -D warnings
+
+  docs:
+    name: Docs
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: "-D warnings"
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo doc --no-deps --features build,langneg
+
+  msrv:
+    name: MSRV (1.88)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@1.88.0
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --features build,langneg

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "fluent-typed"
 version = "0.6.2"
 edition = "2024"
+rust-version = "1.88"
 description = "Type-safe access to Fluent localization messages"
 keywords = ["fluent", "internationalization", "localization"]
 categories = [
@@ -40,3 +41,8 @@ criterion = "0.8"
 name = "build_pipeline"
 harness = false
 required-features = ["bench-internals"]
+
+# Document exactly the public feature surface on docs.rs. `bench-internals` is
+# deliberately excluded — it is not part of the stable public API.
+[package.metadata.docs.rs]
+features = ["build", "langneg"]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![crates.io](https://img.shields.io/crates/v/fluent-typed.svg)](https://crates.io/crates/fluent-typed)
 [![docs.rs](https://docs.rs/fluent-typed/badge.svg)](https://docs.rs/fluent-typed)
+[![CI](https://github.com/human-solutions/fluent-typed/actions/workflows/rust.yml/badge.svg)](https://github.com/human-solutions/fluent-typed/actions/workflows/rust.yml)
+[![msrv](https://img.shields.io/crates/msrv/fluent-typed.svg)](https://github.com/human-solutions/fluent-typed)
 [![license](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 
 **Your [Fluent](https://projectfluent.org) translations as typed Rust functions.** A
@@ -53,6 +55,29 @@ strs.msg_helo("Sam");    // ✗ misspelled key — caught at compile time
 > To get the unused-message warnings, generate the file in the crate that *uses* the
 > accessors, and keep the generated `L10n`/`L10nLanguage` types out of that crate's
 > public API — otherwise every message looks "used".
+
+## How it compares
+
+The established way to get compile-time-checked Fluent in Rust is
+[`i18n-embed`](https://crates.io/crates/i18n-embed) with its
+[`i18n-embed-fl`](https://crates.io/crates/i18n-embed-fl) `fl!` macro, which checks a
+message id and its arguments where you call it. fluent-typed takes a different route: a
+build script generates one typed Rust function per message.
+
+|                              | fluent-typed                                  | `fl!` macro (`i18n-embed-fl`)            |
+| ---------------------------- | --------------------------------------------- | ---------------------------------------- |
+| Call site                    | `strs.msg_hello("Sam")` — a real method       | `fl!(LOADER, "hello", name = "Sam")`     |
+| Editor support               | autocomplete, go-to-definition, rename        | string ids, no completion                |
+| Unused translations          | `cargo` **warning** for messages you dropped  | not detected                             |
+| Argument types               | inferred & enforced (`String`/`Number`/…)     | checked as present                       |
+| Output                       | plain Rust you can read & commit              | macro-expanded at the call site          |
+
+Trade-offs, honestly: fluent-typed runs a build script and commits a generated file,
+where `i18n-embed` has no codegen step; `i18n-embed` has a much larger ecosystem and
+user base; and fluent-typed needs a recent toolchain (see
+[Versioning and MSRV](#versioning-and-msrv)). Pick fluent-typed when you want
+translations to feel like ordinary typed functions and want dead keys to surface
+themselves.
 
 ## Usage
 
@@ -122,16 +147,17 @@ fn main() -> std::process::ExitCode {
 ```rust
 // in lib.rs or main.rs
 mod l10n;
-use l10n::L10n;
+use l10n::{L10n, L10nLanguage};
 
 // Load English translations into an L10nLanguage struct.
 // It provides safe functions for accessing all messages.
-let strs: L10nLanguage = L10n::EnGb.load();
+let strs: L10nLanguage = L10n::En.load();
 
 // With the feature "langneg" enabled you can do automatic language
 // negotiation, which falls back on the default language as
 // configured in the BuildOptions in build.rs when generating.
-let found_lang: L10nLanguage = L10n::langneg("en");
+// `langneg` returns the closest available `L10n`; call `.load()` on it.
+let negotiated: L10nLanguage = L10n::langneg("en").load();
 
 // In Dioxus/Leptos/Silkenweb etc the L10nLanguage struct is typically
 // used inside of a Signal or other reactive construct, so that all
@@ -270,8 +296,8 @@ text rendered in a bidi-aware context such as a web UI: it keeps an interpolated
 value's text direction from corrupting the surrounding message, which matters
 whenever a right-to-left locale is used or user-provided text is interpolated.
 
-```rust
-// strs.msg_hello("world") == "Hello \u{2068}world\u{2069}"
+```text
+strs.msg_hello("world") == "Hello \u{2068}world\u{2069}"
 ```
 
 If the generated strings are never rendered in a bidi-aware context — and you do
@@ -282,3 +308,14 @@ the marks off:
 // in build.rs
 let options = BuildOptions::default().without_bidi_isolation();
 ```
+
+## Versioning and MSRV
+
+The minimum supported Rust version is **1.88** (the crate uses the 2024 edition and
+let-chains). Raising the MSRV is treated as a minor-version change.
+
+fluent-typed is pre-1.0 and its API is still settling — minor releases may contain
+breaking changes, each called out in the [CHANGELOG](./CHANGELOG.md). The runtime
+re-exports of `fluent-bundle` types (`FluentArgs`, `FluentValue`, `FluentNumber`)
+track that crate's own (pre-1.0) releases. Pin a minor version (`fluent-typed = "0.6"`)
+and read the changelog before upgrading.


### PR DESCRIPTION
Release-readiness pass ahead of promoting the crate. No library code changes — CI, packaging metadata, and docs only.

## CI (`.github/workflows/rust.yml`)
Replaces the single build+test job with five focused jobs, on `dtolnay/rust-toolchain` + `Swatinem/rust-cache`:
- **test** (stable)
- **rustfmt** (`--check`)
- **clippy** (`-D warnings`)
- **doc** (`RUSTDOCFLAGS=-D warnings`)
- **MSRV** (pinned 1.88)

All five pass locally.

## Packaging (`Cargo.toml`)
- Declare `rust-version = "1.88"`. Verified empirically: builds on 1.88/1.89, fails on 1.86 (edition 2024 + let-chains).
- Add `[package.metadata.docs.rs]` pinning the public features (`build`, `langneg`) so the non-public `bench-internals` stays out of rendered docs.

## README
- New **"How it compares"** section positioning against `i18n-embed-fl`.
- New **"Versioning and MSRV"** section (MSRV policy + the pre-1.0 / fluent-bundle re-export caveat).
- CI + MSRV badges.
- Fixed three doc bugs in the usage example:
  - `L10nLanguage` was used but never imported.
  - `L10n::EnGb` should be `L10n::En` (consistent with the rest).
  - **`L10n::langneg` returns `L10n`, not `L10nLanguage`** — the old example didn't type-check.
- Converted an empty ```rust block to ```text so `cargo doc -D warnings` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)