### PR TITLE
Seal BuildOptions fields against additive breakage (0.7.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.7.0 (unreleased)
+
+### Changed
+- **Breaking:** `BuildOptions`' fields are now private. Build it from
+  `BuildOptions::default()` and the `with_*` / `without_*` builder methods
+  rather than struct-literal syntax or direct field assignment. Every field
+  already has a corresponding builder method, so existing
+  `BuildOptions::default().with_…()` chains are unaffected — only code that
+  constructed the struct directly or read its fields needs to change. This
+  lets future options be added in a minor release without breaking your
+  build script.
+
 ## 0.6.2
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluent-typed"
-version = "0.6.2"
+version = "0.7.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Type-safe access to Fluent localization messages"

--- a/src/build/options/build_options.rs
+++ b/src/build/options/build_options.rs
@@ -3,55 +3,72 @@ use super::lint_level::LintLevel;
 
 const DEFAULT_PREFIX: &str = "msg_";
 
+/// Configuration for the build-time code generation performed by
+/// [`build_from_locales_folder`](crate::build_from_locales_folder) and
+/// [`try_build_from_locales_folder`](crate::try_build_from_locales_folder).
+///
+/// Start from [`BuildOptions::default`] and adjust it with the `with_*` /
+/// `without_*` builder methods:
+///
+/// ```no_run
+/// # use fluent_typed::{BuildOptions, LintLevel};
+/// let options = BuildOptions::default()
+///     .with_locales_folder("locales")
+///     .with_lint_level(LintLevel::Deny);
+/// ```
+///
+/// The fields are private on purpose: this lets new options be added in a minor
+/// release without breaking direct struct construction in your build script.
+/// Every option has a corresponding builder method.
 pub struct BuildOptions {
     /// The path to the folder containing the locales.
     ///
     /// Defaults to "locales".
-    pub locales_folder: String,
+    pub(crate) locales_folder: String,
 
     /// The path to the file where the generated code will be written. It is recommended
     /// to use a path inside of `src/` and to include the file in the project so that
     /// you get warnings for unused translation messages.
     ///
     /// Defaults to "src/l10n.rs".
-    pub output_file_path: String,
+    pub(crate) output_file_path: String,
 
     /// The the ftl output options, which let you configure how the output ftl
     /// files are generated and accessed.
-    pub ftl_output: FtlOutputOptions,
+    pub(crate) ftl_output: FtlOutputOptions,
 
     /// The indentation used in the generated file.
     ///
     /// Defaults to four spaces.
-    pub indentation: String,
+    pub(crate) indentation: String,
 
     /// The default language to use for the L10n enum. An error is thrown
     /// during build if the default language is not found in the locales.
     ///
     /// It defaults to "en"
-    pub default_language: String,
+    pub(crate) default_language: String,
 
     /// Whether to format the generated file or not (uses rustfmt).
     ///
     /// Defaults to true.
-    pub format: bool,
+    pub(crate) format: bool,
 
     /// The prefix prepended to every generated message accessor's name,
     /// e.g. `"msg_"` produces `msg_hello_world()`.
     ///
     /// Defaults to `"msg_"`.
-    pub prefix: String,
+    pub(crate) prefix: String,
 
     /// Whether to return an error if duplicate message keys are found
     /// within the same language.
     ///
     /// Defaults to true.
-    pub deny_duplicate_keys: bool,
+    pub(crate) deny_duplicate_keys: bool,
 
     /// How strictly the comments in your `.ftl` files are checked.
     ///
     /// Defaults to [`LintLevel::Warn`].
-    pub lint_level: LintLevel,
+    pub(crate) lint_level: LintLevel,
 
     /// Whether the generated code wraps interpolated variables in Unicode
     /// bidi isolation marks (FSI `U+2068` / PDI `U+2069`).
@@ -61,7 +78,7 @@ pub struct BuildOptions {
     /// right-to-left locale is used or user-provided text is interpolated.
     ///
     /// Defaults to true.
-    pub use_isolating: bool,
+    pub(crate) use_isolating: bool,
 }
 
 impl Default for BuildOptions {
@@ -82,43 +99,57 @@ impl Default for BuildOptions {
 }
 
 impl BuildOptions {
+    /// Set the folder scanned for `<lang-id>/<resource>.ftl` files.
+    /// Defaults to `"locales"`.
     pub fn with_locales_folder(mut self, locales_folder: &str) -> Self {
         self.locales_folder = locales_folder.to_string();
         self
     }
 
+    /// Set the path the generated Rust file is written to. Keeping it inside
+    /// `src/` (the default `"src/l10n.rs"`) and committing it is what produces
+    /// the unused-message warnings.
     pub fn with_output_file_path(mut self, output_file_path: &str) -> Self {
         self.output_file_path = output_file_path.to_string();
         self
     }
 
+    /// Set the indentation used in the generated file. Defaults to four spaces.
     pub fn with_indentation(mut self, indentation: &str) -> Self {
         self.indentation = indentation.to_string();
         self
     }
 
+    /// Set how the joined FTL is emitted (single embedded file vs. one file per
+    /// language). See [`FtlOutputOptions`].
     pub fn with_ftl_output(mut self, opts: FtlOutputOptions) -> Self {
         self.ftl_output = opts;
         self
     }
 
+    /// Set the default locale — the single source of truth for every message's
+    /// typed signature. A build error is raised if it has no subfolder in the
+    /// locales folder. Defaults to `"en"`.
     pub fn with_default_language(mut self, lang: &str) -> Self {
         self.default_language = lang.to_string();
         self
     }
 
+    /// Do not run `rustfmt` on the generated file. Formatting is on by default.
     pub fn without_format(mut self) -> Self {
         self.format = false;
         self
     }
 
-    /// Set the prefix prepended to every generated message accessor's name.
-    /// See [`BuildOptions::prefix`].
+    /// Set the prefix prepended to every generated message accessor's name,
+    /// e.g. `"msg_"` produces `msg_hello_world()`. Defaults to `"msg_"`.
     pub fn with_prefix(mut self, prefix: &str) -> Self {
         self.prefix = prefix.to_string();
         self
     }
 
+    /// Allow duplicate message keys within a language instead of failing the
+    /// build. Duplicates are denied by default.
     pub fn with_allow_duplicate_keys(mut self) -> Self {
         self.deny_duplicate_keys = false;
         self
@@ -131,8 +162,8 @@ impl BuildOptions {
         self
     }
 
-    /// Disable Unicode bidi isolation marks around interpolated variables
-    /// in the generated code. See [`BuildOptions::use_isolating`].
+    /// Disable the Unicode bidi isolation marks (FSI `U+2068` / PDI `U+2069`)
+    /// that the generated code otherwise wraps around interpolated variables.
     ///
     /// Only do this if the generated strings are never rendered in a
     /// bidi-aware context, or you never use right-to-left locales or


### PR DESCRIPTION
First of the batched **0.7** breaking changes on the road to 1.0. Targets road-to-1.0 item #1.

## What & why
Every `BuildOptions` field is now `pub(crate)`, so the struct can only be built via `BuildOptions::default()` + the existing `with_*` / `without_*` builder methods. This makes **adding a future option a non-breaking minor release** instead of breaking direct struct construction — the exact churn that forced a breaking change in both 0.5 and 0.6 ("Direct struct construction must include these fields").

This is breaking *only* for downstream code that built the struct with literal syntax or read its fields directly. `default().with_…()` chains — the documented and only path used in this repo (README, playground, benches, tests) — are unaffected.

## Changes
- `src/build/options/build_options.rs`: fields `pub` → `pub(crate)`; added a struct-level doc with a usage example; documented every previously-undocumented builder method (field docs are no longer public).
- Reworded `with_prefix` / `without_bidi_isolation` docs to drop intra-doc links that now resolve to private fields — they would fail the `cargo doc -D warnings` CI job.
- `Cargo.toml`: `0.6.2` → `0.7.0`.
- `CHANGELOG.md`: `## 0.7.0 (unreleased)` entry.

## Verification (local, all green)
- `cargo test --features build,langneg` — 100 unit + 1 playground integration test pass
- `cargo fmt --all --check`, `cargo clippy --all-targets --features build,langneg -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --features build,langneg`
- `cargo build --benches --features bench-internals` (external-consumer path)

## Scope note
`FtlOutputOptions` has the same additive-breakage exposure but its `MultiFile { … }` variant is constructed by literal in the playground, so sealing it needs a small migration — that's a follow-up PR landing in the same unreleased 0.7, so users still break only once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)