### PR TITLE
Seal FtlOutputOptions against additive breakage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## 0.7.0 (unreleased)
 
 ### Changed
+- **Breaking:** `FtlOutputOptions` and its variants are now `#[non_exhaustive]`.
+  Construct it with `FtlOutputOptions::single_file()`,
+  `single_compressed_file()` or `multi_file()` instead of the
+  `FtlOutputOptions::SingleFile { .. }` / `MultiFile { .. }` struct-literal
+  syntax. This lets new output modes and fields be added in a minor release.
 - **Breaking:** `BuildOptions`' fields are now private. Build it from
   `BuildOptions::default()` and the `with_*` / `without_*` builder methods
   rather than struct-literal syntax or direct field assignment. Every field

--- a/playground/example1/build.rs
+++ b/playground/example1/build.rs
@@ -15,9 +15,7 @@ fn main() -> ExitCode {
 
 fn try_main() -> Result<(), BuildError> {
     let multi_opts = BuildOptions::default()
-        .with_ftl_output(FtlOutputOptions::MultiFile {
-            output_ftl_folder: "gen/multi/".to_string(),
-        })
+        .with_ftl_output(FtlOutputOptions::multi_file("gen/multi/"))
         .with_output_file_path("src/multi_l10n.rs");
     try_build_from_locales_folder(multi_opts)?;
 

--- a/src/build/options/ftl_output_options.rs
+++ b/src/build/options/ftl_output_options.rs
@@ -12,8 +12,11 @@ type CompressorFn = dyn Fn(Vec<u8>) -> Result<Vec<u8>, Box<dyn Error>>;
 /// configure how the output ftl files are generated, and also what
 /// type of access code is generated.
 ///
-/// Defaults to a SingleFileOptions with the output_ftl_folder set to "gen"
-/// and gzip set to true.
+/// Build it with [`FtlOutputOptions::single_file`],
+/// [`FtlOutputOptions::single_compressed_file`] or
+/// [`FtlOutputOptions::multi_file`] (the default is a single uncompressed file
+/// at `gen/translations.ftl`).
+#[non_exhaustive]
 pub enum FtlOutputOptions {
     /// Generates FTL files as one file per language which means
     /// that individual resource files are appended into one file.
@@ -21,6 +24,7 @@ pub enum FtlOutputOptions {
     /// This is especially useful client-side when you
     /// don't want to embed the files in the binary or
     /// download them all together.
+    #[non_exhaustive]
     MultiFile {
         /// The path to the where the output ftl files will be written.
         /// For convenience fluent-typed joins all ftl resources for each language
@@ -37,6 +41,7 @@ pub enum FtlOutputOptions {
     /// which typically is done server-side and also client-side when
     /// the files are small enough to either embed in the binary or
     /// download in a html request.
+    #[non_exhaustive]
     SingleFile {
         /// The path to the where the output ftl file will be written.
         /// For convenience fluent-typed joins all ftl resources for each language
@@ -64,6 +69,8 @@ impl Default for FtlOutputOptions {
 }
 
 impl FtlOutputOptions {
+    /// All languages joined into one uncompressed `.ftl` file at `file`,
+    /// suitable for embedding in the binary (server-side) or a single download.
     pub fn single_file(file: &str) -> Self {
         Self::SingleFile {
             output_ftl_file: file.to_string(),
@@ -71,6 +78,9 @@ impl FtlOutputOptions {
         }
     }
 
+    /// Like [`single_file`](Self::single_file), but the joined bytes are passed
+    /// through `compressor` before being written. You bring the compression
+    /// crate and must decompress the bytes the same way at load time.
     pub fn single_compressed_file<F>(file: &str, compressor: F) -> Self
     where
         F: Fn(Vec<u8>) -> Result<Vec<u8>, Box<dyn Error>> + 'static,
@@ -81,6 +91,8 @@ impl FtlOutputOptions {
         }
     }
 
+    /// One `.ftl` file per language written into `folder`, for loading a single
+    /// language on demand rather than embedding them all.
     pub fn multi_file(folder: &str) -> Self {
         Self::MultiFile {
             output_ftl_folder: folder.to_string(),


### PR DESCRIPTION
Second of the batched **0.7** breaking changes on the road to 1.0 (continues road-to-1.0 item #1, version already at 0.7.0 from #25).

## What & why
`FtlOutputOptions` and both its variants are now `#[non_exhaustive]`, so downstream build scripts must use the `single_file()`, `single_compressed_file()` or `multi_file()` constructors rather than the `SingleFile { .. }` / `MultiFile { .. }` struct-literal syntax. This makes **new output modes (variants) and new fields on existing variants non-breaking** minor releases.

Unlike `BuildOptions` (a struct, sealed with `pub(crate)` fields in #25), enum variant fields can't carry their own visibility — `#[non_exhaustive]` is the correct mechanism for an enum. In-crate construction (the three constructors, `Default`, and all tests) is unaffected.

## Changes
- `src/build/options/ftl_output_options.rs`: `#[non_exhaustive]` on the enum and on `MultiFile` / `SingleFile`; documented the three constructors (the variant-field docs are no longer reachable externally).
- `playground/example1/build.rs`: migrated the one `MultiFile { .. }` literal to `FtlOutputOptions::multi_file("gen/multi/")` — this is the external consumer the sealing breaks, and the proof the new API covers the use case.
- `CHANGELOG.md`: added to the `0.7.0` entry.

## Verification (local, all green)
- `cargo test --features build,langneg` — 100 unit + 1 playground integration test
- `cargo fmt --all --check`, `cargo clippy --all-targets --features build,langneg -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --features build,langneg`
- `cargo build --benches --features bench-internals`
- playground rebuild: generated output is byte-identical (codegen path untouched)

## Remaining 0.7 work
3. Typed runtime errors (replace `Result<_, String>` in `L10nBundle` / `L10nLanguageVec` / `L10nLanguage`) — the largest, next as its own PR.
4. Remove public-API panics (`L10nLanguageVec::get`, generated `load()`/`load_all()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)