### PR TITLE
Fix MSRV badge showing "unknown"

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![crates.io](https://img.shields.io/crates/v/fluent-typed.svg)](https://crates.io/crates/fluent-typed)
 [![docs.rs](https://docs.rs/fluent-typed/badge.svg)](https://docs.rs/fluent-typed)
 [![CI](https://github.com/human-solutions/fluent-typed/actions/workflows/rust.yml/badge.svg)](https://github.com/human-solutions/fluent-typed/actions/workflows/rust.yml)
-[![msrv](https://img.shields.io/crates/msrv/fluent-typed.svg)](https://github.com/human-solutions/fluent-typed)
+[![msrv](https://img.shields.io/badge/MSRV-1.88-blue.svg)](https://github.com/human-solutions/fluent-typed)
 [![license](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 
 **Your [Fluent](https://projectfluent.org) translations as typed Rust functions.** A


### PR DESCRIPTION
The `msrv` badge rendered **"unknown"** because `img.shields.io/crates/msrv/fluent-typed` reads the MSRV from the latest *published* crate (still **0.6.2**), which predates the `rust-version = "1.88"` field added in the unreleased 0.7.0.

Switched to a static badge (`MSRV 1.88`) that reflects the repo's actual minimum and matches `Cargo.toml`'s `rust-version` and the MSRV CI job. Bump the number alongside those if the MSRV ever changes.

(The dynamic `crates/msrv` badge would start working once 0.7.0 is published, but a static badge avoids the "unknown" window and always tracks the repo rather than the last release.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)