### PR TITLE
Add try_get and document the remaining public-API panics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@
   the prelude). It is `#[non_exhaustive]` and carries owned strings rather than
   `fluent-bundle`'s own error types, so it stays stable across fluent-bundle
   updates.
+- `L10nLanguageVec::try_get`, a non-panicking lookup returning
+  `Option<&L10nBundle>`. Use it when the language id comes from outside the
+  loaded set (a raw header, a query parameter, user input) and a miss is a case
+  to handle rather than a bug. `get` remains for known `L10n` variants but now
+  documents its panic precondition, and the generated `load`/`load_all`
+  accessors carry a diagnostic message instead of a bare `unwrap`. (These are
+  additive — no existing call needs to change.)
 
 ### Changed
 - **Breaking:** the runtime API now returns `Result<_, L10nError>` instead of

--- a/playground/example1/src/single_l10n.rs
+++ b/playground/example1/src/single_l10n.rs
@@ -103,7 +103,8 @@ impl L10n {
     /// Load a L10nLanguage from the embedded data.
     pub fn load(&self) -> L10nLanguage {
         let bytes = LANG_DATA[self.byte_range()].to_vec();
-        L10nLanguage::new(self, &bytes).unwrap()
+        L10nLanguage::new(self, &bytes)
+            .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 
     /// Load all languages (L10nLanguage) from the embedded data.
@@ -112,7 +113,7 @@ impl L10n {
             LANG_DATA,
             Self::iter().map(|lang| (lang, lang.byte_range())),
         )
-        .unwrap()
+        .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 }
 

--- a/src/build/gen/generated_ftl.rs
+++ b/src/build/gen/generated_ftl.rs
@@ -72,7 +72,8 @@ impl GeneratedFtl {
     /// Load a L10nLanguage from the embedded data.
     pub fn load(&self) -> L10nLanguage {
         let bytes = LANG_DATA[self.byte_range()].to_vec();
-        L10nLanguage::new(self, &bytes).unwrap()
+        L10nLanguage::new(self, &bytes)
+            .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 "#
         };
@@ -103,7 +104,7 @@ impl GeneratedFtl {
             LANG_DATA,
             Self::iter().map(|lang| (lang, lang.byte_range())),
         )
-        .unwrap()
+        .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }"#
         };
 

--- a/src/l10n_language_vec.rs
+++ b/src/l10n_language_vec.rs
@@ -47,11 +47,36 @@ impl L10nLanguageVec {
         })
     }
 
-    /// IMPORTANT, the lang argument should be a L10n enum variant
+    /// Get the bundle for `lang`, or `None` if no such language was loaded.
+    ///
+    /// `lang` is matched against the language ids the vec was loaded from (the
+    /// `L10n` enum variants). Reach for this when `lang` comes from outside that
+    /// set — a raw header, a query parameter, user input — and a miss is a case
+    /// you want to handle rather than a bug. When you already hold a known `L10n`
+    /// variant, [`Self::get`] is more convenient.
+    pub fn try_get(&self, lang: impl AsRef<str>) -> Option<&L10nBundle> {
+        let lang = lang.as_ref();
+        self.langs.iter().find(|b| b.lang() == lang)
+    }
+
+    /// Get the bundle for `lang`.
+    ///
+    /// Pass an `L10n` enum variant (one of the languages the vec was loaded
+    /// from); the lookup is then guaranteed to succeed. The variant returned by
+    /// the generated `L10n::langneg` always qualifies.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `lang` was not loaded. Use [`Self::try_get`] when `lang` may be
+    /// outside the loaded set and you want to handle the miss.
     pub fn get(&self, lang: impl AsRef<str>) -> &L10nBundle {
-        self.langs
-            .iter()
-            .find(|b| b.lang() == lang.as_ref())
-            .unwrap()
+        let lang = lang.as_ref();
+        self.try_get(lang).unwrap_or_else(|| {
+            panic!(
+                "L10nLanguageVec::get: language '{lang}' was not loaded. Pass an \
+                 `L10n` enum variant (the languages the vec was loaded from), or \
+                 use `try_get` to handle a missing language."
+            )
+        })
     }
 }

--- a/src/tests/gen/attrib_only_gen.rs
+++ b/src/tests/gen/attrib_only_gen.rs
@@ -88,7 +88,8 @@ impl L10n {
     /// Load a L10nLanguage from the embedded data.
     pub fn load(&self) -> L10nLanguage {
         let bytes = LANG_DATA[self.byte_range()].to_vec();
-        L10nLanguage::new(self, &bytes).unwrap()
+        L10nLanguage::new(self, &bytes)
+            .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 
     /// Load all languages (L10nLanguage) from the embedded data.
@@ -97,7 +98,7 @@ impl L10n {
             LANG_DATA,
             Self::iter().map(|lang| (lang, lang.byte_range())),
         )
-        .unwrap()
+        .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 }
 

--- a/src/tests/gen/complex_gen.rs
+++ b/src/tests/gen/complex_gen.rs
@@ -88,7 +88,8 @@ impl L10n {
     /// Load a L10nLanguage from the embedded data.
     pub fn load(&self) -> L10nLanguage {
         let bytes = LANG_DATA[self.byte_range()].to_vec();
-        L10nLanguage::new(self, &bytes).unwrap()
+        L10nLanguage::new(self, &bytes)
+            .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 
     /// Load all languages (L10nLanguage) from the embedded data.
@@ -97,7 +98,7 @@ impl L10n {
             LANG_DATA,
             Self::iter().map(|lang| (lang, lang.byte_range())),
         )
-        .unwrap()
+        .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 }
 

--- a/src/tests/gen/msg_element_gen.rs
+++ b/src/tests/gen/msg_element_gen.rs
@@ -88,7 +88,8 @@ impl L10n {
     /// Load a L10nLanguage from the embedded data.
     pub fn load(&self) -> L10nLanguage {
         let bytes = LANG_DATA[self.byte_range()].to_vec();
-        L10nLanguage::new(self, &bytes).unwrap()
+        L10nLanguage::new(self, &bytes)
+            .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 
     /// Load all languages (L10nLanguage) from the embedded data.
@@ -97,7 +98,7 @@ impl L10n {
             LANG_DATA,
             Self::iter().map(|lang| (lang, lang.byte_range())),
         )
-        .unwrap()
+        .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 }
 

--- a/src/tests/gen/msg_number_fn_gen.rs
+++ b/src/tests/gen/msg_number_fn_gen.rs
@@ -88,7 +88,8 @@ impl L10n {
     /// Load a L10nLanguage from the embedded data.
     pub fn load(&self) -> L10nLanguage {
         let bytes = LANG_DATA[self.byte_range()].to_vec();
-        L10nLanguage::new(self, &bytes).unwrap()
+        L10nLanguage::new(self, &bytes)
+            .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 
     /// Load all languages (L10nLanguage) from the embedded data.
@@ -97,7 +98,7 @@ impl L10n {
             LANG_DATA,
             Self::iter().map(|lang| (lang, lang.byte_range())),
         )
-        .unwrap()
+        .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 }
 

--- a/src/tests/gen/msg_number_gen.rs
+++ b/src/tests/gen/msg_number_gen.rs
@@ -88,7 +88,8 @@ impl L10n {
     /// Load a L10nLanguage from the embedded data.
     pub fn load(&self) -> L10nLanguage {
         let bytes = LANG_DATA[self.byte_range()].to_vec();
-        L10nLanguage::new(self, &bytes).unwrap()
+        L10nLanguage::new(self, &bytes)
+            .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 
     /// Load all languages (L10nLanguage) from the embedded data.
@@ -97,7 +98,7 @@ impl L10n {
             LANG_DATA,
             Self::iter().map(|lang| (lang, lang.byte_range())),
         )
-        .unwrap()
+        .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 }
 

--- a/src/tests/gen/msg_string_gen.rs
+++ b/src/tests/gen/msg_string_gen.rs
@@ -88,7 +88,8 @@ impl L10n {
     /// Load a L10nLanguage from the embedded data.
     pub fn load(&self) -> L10nLanguage {
         let bytes = LANG_DATA[self.byte_range()].to_vec();
-        L10nLanguage::new(self, &bytes).unwrap()
+        L10nLanguage::new(self, &bytes)
+            .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 
     /// Load all languages (L10nLanguage) from the embedded data.
@@ -97,7 +98,7 @@ impl L10n {
             LANG_DATA,
             Self::iter().map(|lang| (lang, lang.byte_range())),
         )
-        .unwrap()
+        .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 }
 

--- a/src/tests/gen/msg_text_gen.rs
+++ b/src/tests/gen/msg_text_gen.rs
@@ -88,7 +88,8 @@ impl L10n {
     /// Load a L10nLanguage from the embedded data.
     pub fn load(&self) -> L10nLanguage {
         let bytes = LANG_DATA[self.byte_range()].to_vec();
-        L10nLanguage::new(self, &bytes).unwrap()
+        L10nLanguage::new(self, &bytes)
+            .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 
     /// Load all languages (L10nLanguage) from the embedded data.
@@ -97,7 +98,7 @@ impl L10n {
             LANG_DATA,
             Self::iter().map(|lang| (lang, lang.byte_range())),
         )
-        .unwrap()
+        .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 }
 

--- a/src/tests/gen/msg_with_attrib_gen.rs
+++ b/src/tests/gen/msg_with_attrib_gen.rs
@@ -88,7 +88,8 @@ impl L10n {
     /// Load a L10nLanguage from the embedded data.
     pub fn load(&self) -> L10nLanguage {
         let bytes = LANG_DATA[self.byte_range()].to_vec();
-        L10nLanguage::new(self, &bytes).unwrap()
+        L10nLanguage::new(self, &bytes)
+            .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 
     /// Load all languages (L10nLanguage) from the embedded data.
@@ -97,7 +98,7 @@ impl L10n {
             LANG_DATA,
             Self::iter().map(|lang| (lang, lang.byte_range())),
         )
-        .unwrap()
+        .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 }
 

--- a/src/tests/gen/msg_with_var_gen.rs
+++ b/src/tests/gen/msg_with_var_gen.rs
@@ -88,7 +88,8 @@ impl L10n {
     /// Load a L10nLanguage from the embedded data.
     pub fn load(&self) -> L10nLanguage {
         let bytes = LANG_DATA[self.byte_range()].to_vec();
-        L10nLanguage::new(self, &bytes).unwrap()
+        L10nLanguage::new(self, &bytes)
+            .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 
     /// Load all languages (L10nLanguage) from the embedded data.
@@ -97,7 +98,7 @@ impl L10n {
             LANG_DATA,
             Self::iter().map(|lang| (lang, lang.byte_range())),
         )
-        .unwrap()
+        .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 }
 

--- a/src/tests/gen/res_msg_text_gen.rs
+++ b/src/tests/gen/res_msg_text_gen.rs
@@ -88,7 +88,8 @@ impl L10n {
     /// Load a L10nLanguage from the embedded data.
     pub fn load(&self) -> L10nLanguage {
         let bytes = LANG_DATA[self.byte_range()].to_vec();
-        L10nLanguage::new(self, &bytes).unwrap()
+        L10nLanguage::new(self, &bytes)
+            .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 
     /// Load all languages (L10nLanguage) from the embedded data.
@@ -97,7 +98,7 @@ impl L10n {
             LANG_DATA,
             Self::iter().map(|lang| (lang, lang.byte_range())),
         )
-        .unwrap()
+        .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 }
 

--- a/src/tests/gen/test_format_generated_rust_file_gen.rs
+++ b/src/tests/gen/test_format_generated_rust_file_gen.rs
@@ -95,7 +95,8 @@ impl L10n {
     /// Load a L10nLanguage from the embedded data.
     pub fn load(&self) -> L10nLanguage {
         let bytes = LANG_DATA[self.byte_range()].to_vec();
-        L10nLanguage::new(self, &bytes).unwrap()
+        L10nLanguage::new(self, &bytes)
+            .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 
     /// Load all languages (L10nLanguage) from the embedded data.
@@ -104,7 +105,7 @@ impl L10n {
             LANG_DATA,
             Self::iter().map(|lang| (lang, lang.byte_range())),
         )
-        .unwrap()
+        .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 }
 

--- a/src/tests/gen/test_locales_deep_folders_gen.rs
+++ b/src/tests/gen/test_locales_deep_folders_gen.rs
@@ -103,7 +103,8 @@ impl L10n {
     /// Load a L10nLanguage from the embedded data.
     pub fn load(&self) -> L10nLanguage {
         let bytes = LANG_DATA[self.byte_range()].to_vec();
-        L10nLanguage::new(self, &bytes).unwrap()
+        L10nLanguage::new(self, &bytes)
+            .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 
     /// Load all languages (L10nLanguage) from the embedded data.
@@ -112,7 +113,7 @@ impl L10n {
             LANG_DATA,
             Self::iter().map(|lang| (lang, lang.byte_range())),
         )
-        .unwrap()
+        .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 }
 

--- a/src/tests/gen/test_locales_gen.rs
+++ b/src/tests/gen/test_locales_gen.rs
@@ -95,7 +95,8 @@ impl L10n {
     /// Load a L10nLanguage from the embedded data.
     pub fn load(&self) -> L10nLanguage {
         let bytes = LANG_DATA[self.byte_range()].to_vec();
-        L10nLanguage::new(self, &bytes).unwrap()
+        L10nLanguage::new(self, &bytes)
+            .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 
     /// Load all languages (L10nLanguage) from the embedded data.
@@ -104,7 +105,7 @@ impl L10n {
             LANG_DATA,
             Self::iter().map(|lang| (lang, lang.byte_range())),
         )
-        .unwrap()
+        .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 }
 

--- a/src/tests/gen/test_locales_missing_msg_gen.rs
+++ b/src/tests/gen/test_locales_missing_msg_gen.rs
@@ -95,7 +95,8 @@ impl L10n {
     /// Load a L10nLanguage from the embedded data.
     pub fn load(&self) -> L10nLanguage {
         let bytes = LANG_DATA[self.byte_range()].to_vec();
-        L10nLanguage::new(self, &bytes).unwrap()
+        L10nLanguage::new(self, &bytes)
+            .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 
     /// Load all languages (L10nLanguage) from the embedded data.
@@ -104,7 +105,7 @@ impl L10n {
             LANG_DATA,
             Self::iter().map(|lang| (lang, lang.byte_range())),
         )
-        .unwrap()
+        .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 }
 

--- a/src/tests/gen/test_locales_multi_resources_gen.rs
+++ b/src/tests/gen/test_locales_multi_resources_gen.rs
@@ -95,7 +95,8 @@ impl L10n {
     /// Load a L10nLanguage from the embedded data.
     pub fn load(&self) -> L10nLanguage {
         let bytes = LANG_DATA[self.byte_range()].to_vec();
-        L10nLanguage::new(self, &bytes).unwrap()
+        L10nLanguage::new(self, &bytes)
+            .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 
     /// Load all languages (L10nLanguage) from the embedded data.
@@ -104,7 +105,7 @@ impl L10n {
             LANG_DATA,
             Self::iter().map(|lang| (lang, lang.byte_range())),
         )
-        .unwrap()
+        .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 }
 

--- a/src/tests/gen/test_unformated_generated_rust_file_gen.rs
+++ b/src/tests/gen/test_unformated_generated_rust_file_gen.rs
@@ -95,7 +95,8 @@ impl L10n {
     /// Load a L10nLanguage from the embedded data.
     pub fn load(&self) -> L10nLanguage {
         let bytes = LANG_DATA[self.byte_range()].to_vec();
-        L10nLanguage::new(self, &bytes).unwrap()
+        L10nLanguage::new(self, &bytes)
+            .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 
     /// Load all languages (L10nLanguage) from the embedded data.
@@ -104,7 +105,7 @@ impl L10n {
             LANG_DATA,
             Self::iter().map(|lang| (lang, lang.byte_range())),
         )
-        .unwrap()
+        .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 }
 

--- a/src/tests/runtime.rs
+++ b/src/tests/runtime.rs
@@ -168,3 +168,18 @@ fn language_vec_loads_each_range() {
     assert_eq!(vec.get("en").msg("greeting", None).unwrap(), "Hello");
     assert_eq!(vec.get("de").msg("greeting", None).unwrap(), "Hallo");
 }
+
+#[test]
+fn try_get_returns_none_for_unloaded_language() {
+    let ftl = "greeting = Hello\n";
+    let ranges = [("en", 0..ftl.len())];
+    let vec = L10nLanguageVec::load(ftl.as_bytes(), ranges.into_iter()).unwrap();
+
+    // A loaded language resolves; an unloaded one is `None` rather than a panic.
+    assert!(vec.try_get("en").is_some());
+    assert!(vec.try_get("fr").is_none());
+    assert_eq!(
+        vec.try_get("en").unwrap().msg("greeting", None).unwrap(),
+        "Hello"
+    );
+}

--- a/src/tests/snapshots/fluent_typed__tests__attrib_only.snap
+++ b/src/tests/snapshots/fluent_typed__tests__attrib_only.snap
@@ -93,7 +93,8 @@ impl L10n {
     /// Load a L10nLanguage from the embedded data.
     pub fn load(&self) -> L10nLanguage {
         let bytes = LANG_DATA[self.byte_range()].to_vec();
-        L10nLanguage::new(self, &bytes).unwrap()
+        L10nLanguage::new(self, &bytes)
+            .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 
     /// Load all languages (L10nLanguage) from the embedded data.
@@ -102,7 +103,7 @@ impl L10n {
             LANG_DATA,
             Self::iter().map(|lang| (lang, lang.byte_range())),
         )
-        .unwrap()
+        .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 }
 

--- a/src/tests/snapshots/fluent_typed__tests__complex.snap
+++ b/src/tests/snapshots/fluent_typed__tests__complex.snap
@@ -93,7 +93,8 @@ impl L10n {
     /// Load a L10nLanguage from the embedded data.
     pub fn load(&self) -> L10nLanguage {
         let bytes = LANG_DATA[self.byte_range()].to_vec();
-        L10nLanguage::new(self, &bytes).unwrap()
+        L10nLanguage::new(self, &bytes)
+            .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 
     /// Load all languages (L10nLanguage) from the embedded data.
@@ -102,7 +103,7 @@ impl L10n {
             LANG_DATA,
             Self::iter().map(|lang| (lang, lang.byte_range())),
         )
-        .unwrap()
+        .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 }
 

--- a/src/tests/snapshots/fluent_typed__tests__format_generated_rust_file-2.snap
+++ b/src/tests/snapshots/fluent_typed__tests__format_generated_rust_file-2.snap
@@ -100,7 +100,8 @@ impl L10n {
     /// Load a L10nLanguage from the embedded data.
     pub fn load(&self) -> L10nLanguage {
         let bytes = LANG_DATA[self.byte_range()].to_vec();
-        L10nLanguage::new(self, &bytes).unwrap()
+        L10nLanguage::new(self, &bytes)
+            .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 
     /// Load all languages (L10nLanguage) from the embedded data.
@@ -109,7 +110,7 @@ impl L10n {
             LANG_DATA,
             Self::iter().map(|lang| (lang, lang.byte_range())),
         )
-        .unwrap()
+        .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 }
 

--- a/src/tests/snapshots/fluent_typed__tests__format_generated_rust_file.snap
+++ b/src/tests/snapshots/fluent_typed__tests__format_generated_rust_file.snap
@@ -100,7 +100,8 @@ impl L10n {
     /// Load a L10nLanguage from the embedded data.
     pub fn load(&self) -> L10nLanguage {
         let bytes = LANG_DATA[self.byte_range()].to_vec();
-        L10nLanguage::new(self, &bytes).unwrap()
+        L10nLanguage::new(self, &bytes)
+            .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 
     /// Load all languages (L10nLanguage) from the embedded data.
@@ -109,7 +110,7 @@ impl L10n {
             LANG_DATA,
             Self::iter().map(|lang| (lang, lang.byte_range())),
         )
-        .unwrap()
+        .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 }
 

--- a/src/tests/snapshots/fluent_typed__tests__msg_element.snap
+++ b/src/tests/snapshots/fluent_typed__tests__msg_element.snap
@@ -93,7 +93,8 @@ impl L10n {
     /// Load a L10nLanguage from the embedded data.
     pub fn load(&self) -> L10nLanguage {
         let bytes = LANG_DATA[self.byte_range()].to_vec();
-        L10nLanguage::new(self, &bytes).unwrap()
+        L10nLanguage::new(self, &bytes)
+            .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 
     /// Load all languages (L10nLanguage) from the embedded data.
@@ -102,7 +103,7 @@ impl L10n {
             LANG_DATA,
             Self::iter().map(|lang| (lang, lang.byte_range())),
         )
-        .unwrap()
+        .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 }
 

--- a/src/tests/snapshots/fluent_typed__tests__msg_number.snap
+++ b/src/tests/snapshots/fluent_typed__tests__msg_number.snap
@@ -93,7 +93,8 @@ impl L10n {
     /// Load a L10nLanguage from the embedded data.
     pub fn load(&self) -> L10nLanguage {
         let bytes = LANG_DATA[self.byte_range()].to_vec();
-        L10nLanguage::new(self, &bytes).unwrap()
+        L10nLanguage::new(self, &bytes)
+            .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 
     /// Load all languages (L10nLanguage) from the embedded data.
@@ -102,7 +103,7 @@ impl L10n {
             LANG_DATA,
             Self::iter().map(|lang| (lang, lang.byte_range())),
         )
-        .unwrap()
+        .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 }
 

--- a/src/tests/snapshots/fluent_typed__tests__msg_number_fn.snap
+++ b/src/tests/snapshots/fluent_typed__tests__msg_number_fn.snap
@@ -93,7 +93,8 @@ impl L10n {
     /// Load a L10nLanguage from the embedded data.
     pub fn load(&self) -> L10nLanguage {
         let bytes = LANG_DATA[self.byte_range()].to_vec();
-        L10nLanguage::new(self, &bytes).unwrap()
+        L10nLanguage::new(self, &bytes)
+            .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 
     /// Load all languages (L10nLanguage) from the embedded data.
@@ -102,7 +103,7 @@ impl L10n {
             LANG_DATA,
             Self::iter().map(|lang| (lang, lang.byte_range())),
         )
-        .unwrap()
+        .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 }
 

--- a/src/tests/snapshots/fluent_typed__tests__msg_string.snap
+++ b/src/tests/snapshots/fluent_typed__tests__msg_string.snap
@@ -93,7 +93,8 @@ impl L10n {
     /// Load a L10nLanguage from the embedded data.
     pub fn load(&self) -> L10nLanguage {
         let bytes = LANG_DATA[self.byte_range()].to_vec();
-        L10nLanguage::new(self, &bytes).unwrap()
+        L10nLanguage::new(self, &bytes)
+            .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 
     /// Load all languages (L10nLanguage) from the embedded data.
@@ -102,7 +103,7 @@ impl L10n {
             LANG_DATA,
             Self::iter().map(|lang| (lang, lang.byte_range())),
         )
-        .unwrap()
+        .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 }
 

--- a/src/tests/snapshots/fluent_typed__tests__msg_text.snap
+++ b/src/tests/snapshots/fluent_typed__tests__msg_text.snap
@@ -93,7 +93,8 @@ impl L10n {
     /// Load a L10nLanguage from the embedded data.
     pub fn load(&self) -> L10nLanguage {
         let bytes = LANG_DATA[self.byte_range()].to_vec();
-        L10nLanguage::new(self, &bytes).unwrap()
+        L10nLanguage::new(self, &bytes)
+            .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 
     /// Load all languages (L10nLanguage) from the embedded data.
@@ -102,7 +103,7 @@ impl L10n {
             LANG_DATA,
             Self::iter().map(|lang| (lang, lang.byte_range())),
         )
-        .unwrap()
+        .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 }
 

--- a/src/tests/snapshots/fluent_typed__tests__msg_with_attrib.snap
+++ b/src/tests/snapshots/fluent_typed__tests__msg_with_attrib.snap
@@ -93,7 +93,8 @@ impl L10n {
     /// Load a L10nLanguage from the embedded data.
     pub fn load(&self) -> L10nLanguage {
         let bytes = LANG_DATA[self.byte_range()].to_vec();
-        L10nLanguage::new(self, &bytes).unwrap()
+        L10nLanguage::new(self, &bytes)
+            .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 
     /// Load all languages (L10nLanguage) from the embedded data.
@@ -102,7 +103,7 @@ impl L10n {
             LANG_DATA,
             Self::iter().map(|lang| (lang, lang.byte_range())),
         )
-        .unwrap()
+        .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 }
 

--- a/src/tests/snapshots/fluent_typed__tests__msg_with_var.snap
+++ b/src/tests/snapshots/fluent_typed__tests__msg_with_var.snap
@@ -93,7 +93,8 @@ impl L10n {
     /// Load a L10nLanguage from the embedded data.
     pub fn load(&self) -> L10nLanguage {
         let bytes = LANG_DATA[self.byte_range()].to_vec();
-        L10nLanguage::new(self, &bytes).unwrap()
+        L10nLanguage::new(self, &bytes)
+            .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 
     /// Load all languages (L10nLanguage) from the embedded data.
@@ -102,7 +103,7 @@ impl L10n {
             LANG_DATA,
             Self::iter().map(|lang| (lang, lang.byte_range())),
         )
-        .unwrap()
+        .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 }
 

--- a/src/tests/snapshots/fluent_typed__tests__res_msg_text.snap
+++ b/src/tests/snapshots/fluent_typed__tests__res_msg_text.snap
@@ -93,7 +93,8 @@ impl L10n {
     /// Load a L10nLanguage from the embedded data.
     pub fn load(&self) -> L10nLanguage {
         let bytes = LANG_DATA[self.byte_range()].to_vec();
-        L10nLanguage::new(self, &bytes).unwrap()
+        L10nLanguage::new(self, &bytes)
+            .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 
     /// Load all languages (L10nLanguage) from the embedded data.
@@ -102,7 +103,7 @@ impl L10n {
             LANG_DATA,
             Self::iter().map(|lang| (lang, lang.byte_range())),
         )
-        .unwrap()
+        .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 }
 

--- a/src/tests/snapshots/fluent_typed__tests__test_locales.snap
+++ b/src/tests/snapshots/fluent_typed__tests__test_locales.snap
@@ -100,7 +100,8 @@ impl L10n {
     /// Load a L10nLanguage from the embedded data.
     pub fn load(&self) -> L10nLanguage {
         let bytes = LANG_DATA[self.byte_range()].to_vec();
-        L10nLanguage::new(self, &bytes).unwrap()
+        L10nLanguage::new(self, &bytes)
+            .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 
     /// Load all languages (L10nLanguage) from the embedded data.
@@ -109,7 +110,7 @@ impl L10n {
             LANG_DATA,
             Self::iter().map(|lang| (lang, lang.byte_range())),
         )
-        .unwrap()
+        .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 }
 

--- a/src/tests/snapshots/fluent_typed__tests__test_locales_deep_folders.snap
+++ b/src/tests/snapshots/fluent_typed__tests__test_locales_deep_folders.snap
@@ -108,7 +108,8 @@ impl L10n {
     /// Load a L10nLanguage from the embedded data.
     pub fn load(&self) -> L10nLanguage {
         let bytes = LANG_DATA[self.byte_range()].to_vec();
-        L10nLanguage::new(self, &bytes).unwrap()
+        L10nLanguage::new(self, &bytes)
+            .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 
     /// Load all languages (L10nLanguage) from the embedded data.
@@ -117,7 +118,7 @@ impl L10n {
             LANG_DATA,
             Self::iter().map(|lang| (lang, lang.byte_range())),
         )
-        .unwrap()
+        .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 }
 

--- a/src/tests/snapshots/fluent_typed__tests__test_locales_missing_msg.snap
+++ b/src/tests/snapshots/fluent_typed__tests__test_locales_missing_msg.snap
@@ -100,7 +100,8 @@ impl L10n {
     /// Load a L10nLanguage from the embedded data.
     pub fn load(&self) -> L10nLanguage {
         let bytes = LANG_DATA[self.byte_range()].to_vec();
-        L10nLanguage::new(self, &bytes).unwrap()
+        L10nLanguage::new(self, &bytes)
+            .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 
     /// Load all languages (L10nLanguage) from the embedded data.
@@ -109,7 +110,7 @@ impl L10n {
             LANG_DATA,
             Self::iter().map(|lang| (lang, lang.byte_range())),
         )
-        .unwrap()
+        .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 }
 

--- a/src/tests/snapshots/fluent_typed__tests__test_locales_multi_resources.snap
+++ b/src/tests/snapshots/fluent_typed__tests__test_locales_multi_resources.snap
@@ -100,7 +100,8 @@ impl L10n {
     /// Load a L10nLanguage from the embedded data.
     pub fn load(&self) -> L10nLanguage {
         let bytes = LANG_DATA[self.byte_range()].to_vec();
-        L10nLanguage::new(self, &bytes).unwrap()
+        L10nLanguage::new(self, &bytes)
+            .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 
     /// Load all languages (L10nLanguage) from the embedded data.
@@ -109,7 +110,7 @@ impl L10n {
             LANG_DATA,
             Self::iter().map(|lang| (lang, lang.byte_range())),
         )
-        .unwrap()
+        .expect("fluent-typed: the embedded .ftl could not be loaded. This is a build-time bug; please report it.")
     }
 }
 


### PR DESCRIPTION
The last road-to-1.0 item (#4 of 4): get the public API's panics out of the "looks like sloppiness" category. **This one is additive, not breaking** — no existing call needs to change.

## What & why

I sorted every remaining panic by *who can trigger it*:

| Panic site | Can user input reach it? | Decision |
|---|---|---|
| `L10nLanguageVec::get(impl AsRef<str>)` | **Yes** — any string | Add `try_get -> Option`; keep `get`, document its precondition |
| Generated `load()` / `load_all()` (single-file) | No — embedded, build-validated `.ftl` | Keep infallible; `unwrap()` → diagnostic `expect()` |
| Generated `msg(..).unwrap()` accessors | No — ids/types generated from the same `.ftl` | Leave as-is (documented invariant on `L10nError`) |

Only the first is a genuine footgun: `get` accepts an arbitrary string and panics on a miss. So:

- **`try_get(&self, lang) -> Option<&L10nBundle>`** — the non-panicking path for when the language id comes from outside the loaded set (a raw `Accept-Language`, a query param, user input).
- **`get`** stays for the common case — you pass an `L10n` enum variant, and the generated `L10n::langneg` *always* returns one (it has a `Default` fallback), so the lookup is guaranteed to hit. It now documents the panic precondition and delegates to `try_get`. Matches the stdlib `Index`-panics / `get`-returns-`Option` idiom (names inverted here for back-compat).

The generated single-file `load`/`load_all` are infallible by construction — the `.ftl` is embedded and validated at build time — so they keep their non-`Result` signatures (forcing callers to handle an impossible error would be pure noise; compare the *compressed* `load<D>`, which genuinely returns `Result` because the user's decompressor can fail). The bare `unwrap()` is now an `expect()` that says it's a build-time bug worth reporting.

The generated message accessors are deliberately untouched: a failure there is the same generated-code-vs-embedded-`.ftl` drift invariant already documented on `L10nError`, and adding an `expect` string to every accessor would only bloat the output.

## Verification

- `cargo fmt --check`, `clippy --all-targets --features build,langneg -D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc` — all clean
- 101 unit tests (+1: `try_get` Some/None) + 1 integration (playground) test pass; benches build
- Regenerated all 16 `*_gen.rs` fixtures + snapshots and the playground `single_l10n.rs`; the entire generated diff is *only* `unwrap()` → `expect(..)` on `load`/`load_all` (gzip and multi-file outputs correctly unchanged)

## 0.7 cycle
✅ #25 seal `BuildOptions` · ✅ #26 seal `FtlOutputOptions` · ✅ #28 typed `L10nError` · ✅ this — closes out the 0.7 road-to-1.0 work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)