### PR TITLE
Prepare 0.7.0 release: finalize changelog, trim published crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.7.0 (unreleased)
+## 0.7.0
 
 ### Added
 - `L10nError`, a typed runtime error enum (re-exported from the crate root and

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,10 @@ categories = [
 ]
 license = "MIT"
 repository = "https://github.com/human-solutions/fluent-typed"
+# Keep the published crate lean: ship the library and its docs, not the
+# editor config, AI-assistant notes, or the snapshot/integration test corpus
+# (89 generated fixtures that are noise to anyone reading the source).
+exclude = ["/.vscode", "/CLAUDE.md", "/src/tests", "/tests"]
 
 [lib]
 doctest = false


### PR DESCRIPTION
Pre-publish housekeeping for the first promoted release. No code changes — Cargo metadata + changelog only.

## Changes
- **Finalize the changelog** — drop `(unreleased)` from the `## 0.7.0` heading.
- **Trim the published crate** via Cargo `exclude`. The package was shipping `CLAUDE.md`, `.vscode/`, and 89 snapshot/`*_gen.rs`/`.ftl` test fixtures — noise to anyone reading the source on docs.rs/crates.io. Excluding `/.vscode`, `/CLAUDE.md`, `/src/tests`, `/tests`:

  | | files | compressed |
  |---|---|---|
  | before | 130 | 79.2 KiB |
  | after | 36 | 56.7 KiB |

  `README.md`, `LICENSE`, and the `ftl.bin` codegen fixture are retained. The test files stay on disk — `exclude` only affects packaging — so local `cargo test` and CI are unchanged.

## Verification
- `cargo publish --dry-run` packages **and verify-builds** cleanly with the exclude in place
- 101 unit + 1 integration test pass; `cargo fmt --check` clean

After this merges, 0.7.0 is ready to tag + publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)