### PR TITLE
Tidy the repo and published crate for the 0.7.0 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ Cargo.lock
 
 # Local files
 *.local.*
+
+# Editor config (kept local, not tracked)
+.vscode/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,0 @@
-{
-  "recommendations": ["macabeus.vscode-fluent"]
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-  "rust-analyzer.cargo.features": ["build", "langneg"],
-  "rust-analyzer.check.features": ["build", "langneg"]
-}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,11 @@ categories = [
 ]
 license = "MIT"
 repository = "https://github.com/human-solutions/fluent-typed"
-# Keep the published crate lean: ship the library and its docs, not the
-# editor config, AI-assistant notes, or the snapshot/integration test corpus
-# (89 generated fixtures that are noise to anyone reading the source).
-exclude = ["/.vscode", "/CLAUDE.md", "/src/tests", "/tests"]
+# Keep the published crate lean: drop editor config, AI-assistant notes, and
+# the 89-file snapshot test corpus under src/tests (noise to anyone reading the
+# source). The small tests/ harness is kept so cargo's auto-discovered test
+# targets still resolve at publish time instead of warning that they're missing.
+exclude = ["/.vscode", "/CLAUDE.md", "/src/tests"]
 
 [lib]
 doctest = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,11 @@ categories = [
 ]
 license = "MIT"
 repository = "https://github.com/human-solutions/fluent-typed"
-# Keep the published crate lean: drop editor config, AI-assistant notes, and
-# the 89-file snapshot test corpus under src/tests (noise to anyone reading the
-# source). The small tests/ harness is kept so cargo's auto-discovered test
-# targets still resolve at publish time instead of warning that they're missing.
-exclude = ["/.vscode", "/CLAUDE.md", "/src/tests"]
+# Keep the published crate lean: drop AI-assistant notes and the 89-file
+# snapshot test corpus under src/tests (noise to anyone reading the source).
+# The small tests/ harness is kept so cargo's auto-discovered test targets
+# still resolve at publish time instead of warning that they're missing.
+exclude = ["/CLAUDE.md", "/src/tests"]
 
 [lib]
 doctest = false


### PR DESCRIPTION
Pre-publish tidy-up (follow-up to #30). No library code changes.

### 1. Silence the `cargo publish` warnings
#30's `exclude = [".../tests"]` made publish warn it was ignoring the auto-discovered `common`/`playground` test targets whose files were no longer packaged:

```
warning: ignoring test `common` as `tests/common.rs` is not included in the published package
warning: ignoring test `playground` as `tests/playground.rs` is not included in the published package
```

Fix: drop `/tests` from `exclude`. The two-file harness ships again (as it did in 0.6.x); the meaningful trim — the 89-file `src/tests` snapshot corpus — stays excluded.

### 2. Remove the `.vscode` folder
Delete the tracked editor config from the repo entirely and gitignore `.vscode/` so it won't return. The now-dead `/.vscode` exclude entry is dropped too.

### Result
`cargo publish --dry-run` is warning-free (38 files, 57.6 KiB compressed) and verify-builds clean. Excluded from the package: `CLAUDE.md` and `src/tests/`. Removed from the repo: `.vscode/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)