### PR TITLE
CI: install MSRV toolchain via input instead of pinning the action tag

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,6 +57,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@1.88.0
+      # Install the MSRV toolchain via the `toolchain` input rather than the
+      # `@1.88.0` git ref. dtolnay/rust-toolchain treats its tag as the Rust
+      # version to install, so pinning `@1.88.0` made dependabot keep trying to
+      # bump it to nonexistent Rust releases. Pinning `@stable` (a branch) and
+      # passing the version as an input keeps dependabot out of it while still
+      # verifying the `rust-version` declared in Cargo.toml.
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.88"
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --features build,langneg


### PR DESCRIPTION
## Problem

`dtolnay/rust-toolchain` uses its git ref as the Rust version to install, so the `msrv` job's `@1.88.0` pin doubled as both the action version *and* the toolchain version. Dependabot only sees it as an action version and kept opening PRs to bump it to the latest tag (#32 bumped it to `1.100.0`), which:

1. **Fails immediately** — Rust 1.100.0 doesn't exist, so `rustup` 404s on download.
2. **Would be wrong even if it existed** — the job's entire purpose is to verify the crate still builds on its declared MSRV (`rust-version = "1.88"`). Floating it to the newest toolchain silently defeats that check.

## Fix

Pin the action to the `@stable` branch and pass the MSRV as the `toolchain` input:

```yaml
- uses: dtolnay/rust-toolchain@stable
  with:
    toolchain: "1.88"
```

Dependabot's github-actions updater only rewrites the `uses:` ref, never `with:` inputs, so it leaves this alone — no ignore rule needed. The job still verifies the `rust-version = "1.88"` declared in `Cargo.toml`.

Supersedes and closes #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)