### PR TITLE
Fix clippy 1.97 useless_borrows_in_formatting lint

### DIFF
--- a/src/build/gen/mod.rs
+++ b/src/build/gen/mod.rs
@@ -71,10 +71,7 @@ static ALL_LANGS: [L10n; {}] = [
     // ///////////////////////////
     // `Builder::generate` has already verified that the default language is
     // present in the locales.
-    let default_lang = format!(
-        "        Self::{}",
-        &options.default_language.rust_var_name()
-    );
+    let default_lang = format!("        Self::{}", options.default_language.rust_var_name());
 
     replacements.push(("<<placeholder default lang>>", default_lang));
 


### PR DESCRIPTION
Main went red after merging #31: the Clippy CI job runs latest stable, and clippy 1.97 added `useless_borrows_in_formatting`, flagging a redundant `&` on a `format!` argument in `src/build/gen/mod.rs`. One-line fix (plus the rustfmt collapse of the now-shorter call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)