### PR TITLE
Write all build outputs skip-if-unchanged, comparing final bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,21 @@
   lets future options be added in a minor release without breaking your
   build script.
 
+### Fixed
+- Build outputs are now written skip-if-unchanged, so a no-op rebuild leaves
+  every output file's mtime untouched. Previously the generated `.rs` file was
+  compared against the on-disk file *before* rustfmt ran, so with `format` on
+  (the default) any rustfmt-altered byte — in particular a custom
+  `with_indentation` — meant the guard never fired and every build-script run
+  rewrote the file; the joined `.ftl` outputs were rewritten unconditionally.
+  The mtime bumps retriggered file watchers and `cargo::rerun-if-changed`
+  consumers on every build. Formatting now happens in memory (rustfmt via
+  stdin/stdout) before the compare, which also means a failed rustfmt run no
+  longer leaves an unformatted file on disk.
+- `BuildOptions::with_indentation` now documents that a custom indentation
+  only survives together with `without_format()` — otherwise rustfmt
+  re-indents the generated file and the option is a silent no-op.
+
 ## 0.6.2
 
 ### Changed

--- a/src/build/builder.rs
+++ b/src/build/builder.rs
@@ -1,8 +1,14 @@
 use super::{
     Analyzed, BuildError, BuildOptions, LangBundle, LintLevel, Message, r#gen::generate, lint,
-    typed::Id,
+    typed::Id, utils::write_if_changed,
 };
-use std::{collections::HashSet, fs};
+use std::{
+    collections::HashSet,
+    fs,
+    io::Write,
+    path::Path,
+    process::{Command, Stdio},
+};
 
 pub struct Builder {
     options: BuildOptions,
@@ -63,33 +69,26 @@ impl Builder {
         self.run_lints(default, &analyzed.common)?;
 
         let messages = &self.messages(default, &analyzed.common);
-        let generated = generate(&self.options, &self.langbundles, messages)
+        let mut generated = generate(&self.options, &self.langbundles, messages)
             .map_err(BuildError::Generation)?
             .replace("    ", &self.options.indentation);
 
-        let output_file_path = &self.options.output_file_path;
-        if let Ok(current_file) = fs::read_to_string(output_file_path)
-            && current_file == generated
-        {
-            return Ok(());
-        }
-
-        fs::write(output_file_path, &generated).map_err(|e| BuildError::WriteOutput {
-            path: output_file_path.clone(),
-            source: e,
-        })?;
-
+        // Format before the skip-if-unchanged compare: the file on disk holds
+        // rustfmt's output, so comparing pre-format text against it would
+        // never match and every build would rewrite the file — bumping its
+        // mtime and re-triggering anything watching it. This also means a
+        // rustfmt failure leaves no unformatted file behind.
         if self.options.format {
-            let status = std::process::Command::new("rustfmt")
-                .arg(output_file_path)
-                .status()
-                .map_err(|e| BuildError::Rustfmt(e.to_string()))?;
-            if !status.success() {
-                return Err(BuildError::Rustfmt("rustfmt failed".to_string()));
-            }
+            generated = rustfmt(&generated)?;
         }
 
-        Ok(())
+        let output_file_path = &self.options.output_file_path;
+        write_if_changed(Path::new(output_file_path), generated.as_bytes()).map_err(|e| {
+            BuildError::WriteOutput {
+                path: output_file_path.clone(),
+                source: e,
+            }
+        })
     }
 
     /// Run the comment lints and report them according to the configured
@@ -140,6 +139,37 @@ impl Builder {
     }
 }
 
+/// Format `source` by piping it through rustfmt's stdin/stdout, returning the
+/// formatted text.
+///
+/// Config resolution differs slightly from formatting a file in place:
+/// stdin mode resolves `rustfmt.toml` from the process cwd (the consumer crate
+/// root when run from a build script) upward, while file mode resolves it from
+/// the output file's directory upward. For the normal in-crate `gen/` layout
+/// both walks reach the same crate/workspace config.
+fn rustfmt(source: &str) -> Result<String, BuildError> {
+    let map_io = |e: std::io::Error| BuildError::Rustfmt(e.to_string());
+    let mut child = Command::new("rustfmt")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .map_err(map_io)?;
+    // rustfmt parses all of stdin before emitting anything, so writing the
+    // whole input first cannot deadlock against a filling stdout pipe.
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(source.as_bytes())
+        .map_err(map_io)?;
+    let output = child.wait_with_output().map_err(map_io)?;
+    if !output.status.success() {
+        return Err(BuildError::Rustfmt("rustfmt failed".to_string()));
+    }
+    String::from_utf8(output.stdout)
+        .map_err(|e| BuildError::Rustfmt(format!("rustfmt produced non-UTF-8 output: {e}")))
+}
+
 fn from_locales_folder(
     folder: &str,
     deny_duplicate_keys: bool,
@@ -173,4 +203,21 @@ fn from_locales_folder(
         });
     }
     Ok(locales)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rustfmt_formats_in_memory() {
+        let formatted = rustfmt("fn  main( ){ }\n").unwrap();
+        assert_eq!(formatted, "fn main() {}\n");
+    }
+
+    #[test]
+    fn rustfmt_failure_is_a_build_error() {
+        let err = rustfmt("fn {\n").unwrap_err();
+        assert!(matches!(err, BuildError::Rustfmt(_)), "got: {err:?}");
+    }
 }

--- a/src/build/options/build_options.rs
+++ b/src/build/options/build_options.rs
@@ -39,6 +39,9 @@ pub struct BuildOptions {
 
     /// The indentation used in the generated file.
     ///
+    /// Only effective together with `format: false` — rustfmt re-indents the
+    /// generated file back to its own style, silently undoing this option.
+    ///
     /// Defaults to four spaces.
     pub(crate) indentation: String,
 
@@ -115,6 +118,11 @@ impl BuildOptions {
     }
 
     /// Set the indentation used in the generated file. Defaults to four spaces.
+    ///
+    /// Only takes effect together with
+    /// [`without_format`](Self::without_format): formatting is on by default,
+    /// and rustfmt re-indents the generated file back to its own style
+    /// (4 spaces), silently undoing this option.
     pub fn with_indentation(mut self, indentation: &str) -> Self {
         self.indentation = indentation.to_string();
         self
@@ -136,6 +144,10 @@ impl BuildOptions {
     }
 
     /// Do not run `rustfmt` on the generated file. Formatting is on by default.
+    ///
+    /// Required for [`with_indentation`](Self::with_indentation) to have any
+    /// effect — rustfmt would otherwise re-indent the file back to its own
+    /// style.
     pub fn without_format(mut self) -> Self {
         self.format = false;
         self

--- a/src/build/options/ftl_output_options.rs
+++ b/src/build/options/ftl_output_options.rs
@@ -4,7 +4,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::build::{LangBundle, r#gen::GeneratedFtl};
+use crate::build::{LangBundle, r#gen::GeneratedFtl, utils::write_if_changed};
 
 type CompressorFn = dyn Fn(Vec<u8>) -> Result<Vec<u8>, Box<dyn Error>>;
 
@@ -148,7 +148,8 @@ impl FtlOutputOptions {
 }
 
 fn write(content: &[u8], file: &Path) -> Result<(), String> {
-    fs::write(file, content).map_err(|e| format!("Could not write ftl file '{file:?}': {e:?}"))
+    write_if_changed(file, content)
+        .map_err(|e| format!("Could not write ftl file '{file:?}': {e:?}"))
 }
 
 fn create_dir(folder: &Path) -> Result<(), String> {

--- a/src/build/utils.rs
+++ b/src/build/utils.rs
@@ -1,5 +1,23 @@
 use std::fs;
+use std::io;
 use std::path::{Path, PathBuf};
+
+/// Write `content` to `path` only when it differs from the file's current
+/// content.
+///
+/// Build outputs are watched by consumers — `cargo::rerun-if-changed` on the
+/// generated files, dev-loop file watchers — and several build units may share
+/// one `gen/` dir (host + wasm32 target dirs each keep their own fingerprints
+/// watching the same files). An unconditional rewrite bumps the mtime and
+/// re-triggers all of them on every no-op rebuild.
+pub fn write_if_changed(path: &Path, content: &[u8]) -> io::Result<()> {
+    if let Ok(current) = fs::read(path)
+        && current == content
+    {
+        return Ok(());
+    }
+    fs::write(path, content)
+}
 
 /// A precomputed newline index for one source string.
 ///

--- a/tests/skip_unchanged.rs
+++ b/tests/skip_unchanged.rs
@@ -1,0 +1,65 @@
+//! A no-op rebuild must not rewrite any output file: consumers watch the
+//! generated files (`cargo::rerun-if-changed`, dev-loop file watchers), so a
+//! bumped mtime retriggers them even when the bytes are identical.
+//!
+//! The regression this pins down: the skip-if-unchanged guard used to compare
+//! the *pre*-rustfmt text against the *post*-rustfmt file on disk, so with
+//! `format` on (the default) and a custom indentation the guard never fired
+//! and every build rewrote the file. The `.ftl` outputs were rewritten
+//! unconditionally.
+
+use std::{fs, thread, time::Duration, time::SystemTime};
+
+use fluent_typed::{BuildOptions, FtlOutputOptions, try_build_from_locales_folder};
+
+fn mtime(path: &str) -> SystemTime {
+    fs::metadata(path).unwrap().modified().unwrap()
+}
+
+#[test]
+fn rebuild_with_unchanged_input_leaves_outputs_untouched() {
+    let dir = "target/test-skip-unchanged";
+    fs::create_dir_all(dir).unwrap();
+    let rs = format!("{dir}/l10n.rs");
+    let ftl = format!("{dir}/translations.ftl");
+
+    // The exact repro: format on (the default) together with a custom
+    // indentation, which rustfmt rewrites back to 4 spaces.
+    let options = || {
+        BuildOptions::default()
+            .with_locales_folder("playground/example1/locales")
+            .with_output_file_path(&rs)
+            .with_ftl_output(FtlOutputOptions::single_file(&ftl))
+            .with_indentation("  ")
+    };
+
+    // Clean slate so the first build genuinely writes both files.
+    let _ = fs::remove_file(&rs);
+    let _ = fs::remove_file(&ftl);
+
+    try_build_from_locales_folder(options()).unwrap();
+
+    let rs_bytes = fs::read(&rs).unwrap();
+    let ftl_bytes = fs::read(&ftl).unwrap();
+    let rs_mtime = mtime(&rs);
+    let ftl_mtime = mtime(&ftl);
+
+    // Filesystem mtime granularity can be a full second — make sure a rewrite
+    // in the second build could not hide behind an identical timestamp.
+    thread::sleep(Duration::from_millis(1100));
+
+    try_build_from_locales_folder(options()).unwrap();
+
+    assert_eq!(rs_bytes, fs::read(&rs).unwrap(), "generated .rs changed");
+    assert_eq!(ftl_bytes, fs::read(&ftl).unwrap(), "generated .ftl changed");
+    assert_eq!(
+        rs_mtime,
+        mtime(&rs),
+        "the unchanged .rs output was rewritten"
+    );
+    assert_eq!(
+        ftl_mtime,
+        mtime(&ftl),
+        "the unchanged .ftl output was rewritten"
+    );
+}


### PR DESCRIPTION
A no-op rebuild must leave every output file's mtime untouched: consumers watch the generated files (dev-loop watchers, `cargo::rerun-if-changed` on the outputs), and where several build units share one `gen/` dir (host + wasm32 target dirs each keeping fingerprints on the same files) an unconditional rewrite marks the other unit dirty on every run — perpetual rerun ping-pong.

### The bug
`Builder::generate` had a skip-if-unchanged guard, but it compared the **pre-rustfmt** string against the **post-rustfmt** file on disk:

```rust
if current_file == generated { return Ok(()); }   // compares PRE-format string
fs::write(output_file_path, &generated)?;          // writes pre-format bytes
if self.options.format { /* rustfmt then MUTATES the file */ }
```

With `format` on (the default), whenever rustfmt changes anything — in particular a custom `with_indentation`, which rustfmt re-indents right back — the guard never fired and every build-script run rewrote the file and re-ran rustfmt. Empirically confirmed downstream (fluent-typed 0.6.2, `indentation: "  "`): two consecutive `touch <locale>.ftl && cargo check` runs produced byte-identical `gen/i18n.rs` with the mtime bumped both times.

Second instance: the FTL output helper wrote unconditionally, so all three modes rewrote their `.ftl` outputs every run.

### The fix
- rustfmt now runs **in memory** (stdin/stdout, captured stdout) *before* the compare. Config-resolution nuance is noted in a comment (stdin mode resolves `rustfmt.toml` from the process cwd rather than the output file's dir — same result for the normal in-crate `gen/` layout). No new flags added, parity with the old invocation.
- Both the `.rs` and `.ftl` writes go through one shared `write_if_changed(path, bytes)` helper in `build/utils.rs`.
- Side benefit: a rustfmt failure no longer leaves an unformatted file on disk — nothing is written until formatting succeeded.
- Docs on `with_indentation` / `without_format` now state that a custom indentation only survives with formatting off (the interaction that masked this bug).
- Changelog: added under the still-unpublished 0.7.0 heading (crates.io max is 0.6.2).

### Verification
- New integration test `tests/skip_unchanged.rs` — the exact repro: builds twice with `format` on **and** `with_indentation("  ")` plus a single-file FTL output, asserts bytes *and* mtimes unchanged (with a >1s gap to defeat mtime granularity). Confirmed it **fails** against the previous code and passes with the fix.
- Unit tests for the new `rustfmt` helper: formats valid input; invalid input surfaces `BuildError::Rustfmt` (failure-path parity).
- Full suite (103 unit + playground + new test), clippy `-D warnings`, and `cargo fmt --check` all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)