### PR TITLE
Fix Windows path handling in generated code and test suite

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Checkouts must keep LF regardless of core.autocrlf: the test snapshots
+# record byte offsets and sizes of the .ftl fixtures, so a CRLF checkout
+# (git's default on Windows) shifts every byte range and fails the suite.
+* text=auto eol=lf

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,13 @@ env:
 jobs:
   test:
     name: Test (stable)
-    runs-on: ubuntu-latest
+    # Windows is in the matrix because the generated `include_bytes!` path and
+    # the test-suite portability regress silently on a unix-only matrix
+    # (issue #37).
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.7.1
 
 ### Fixed
 - The generated `include_bytes!` path is now emitted with forward slashes on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- The generated `include_bytes!` path is now emitted with forward slashes on
+  every platform. On Windows it used the native `\` separator, which forms
+  invalid escape sequences inside the string literal and failed the build
+  whenever the generated `.rs` file and the `.ftl` output live in different
+  directories — e.g. a workspace with the locales at the workspace root
+  (#37).
+- On Windows, a generated `.rs` file and an `.ftl` output on *different
+  drives* now produce a clear build error instead of an unbuildable path.
+- The test suite now compiles and passes on Windows: the integration-test
+  helper no longer uses the unix-only `MetadataExt`, the relative-path unit
+  test uses platform-appropriate absolute paths, and a `.gitattributes` pins
+  checkouts to LF so the byte-exact snapshots survive `core.autocrlf=true`.
+  CI now runs the test job on Windows as well.
+
 ## 0.7.0
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fluent-typed"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 rust-version = "1.88"
 description = "Type-safe access to Fluent localization messages"

--- a/playground/example2/.gitignore
+++ b/playground/example2/.gitignore
@@ -1,0 +1,2 @@
+/gen
+/game/src/l10n.rs

--- a/playground/example2/Cargo.toml
+++ b/playground/example2/Cargo.toml
@@ -1,0 +1,3 @@
+[workspace]
+resolver = "2"
+members = ["game"]

--- a/playground/example2/game/Cargo.toml
+++ b/playground/example2/game/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "game"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+fluent-typed = { path = "../../.." }
+
+[build-dependencies]
+fluent-typed = { path = "../../..", features = ["build"] }

--- a/playground/example2/game/build.rs
+++ b/playground/example2/game/build.rs
@@ -1,0 +1,21 @@
+//! Regression setup for issue #37: a workspace member crate whose locales and
+//! generated ftl live at the *workspace* root, so the generated
+//! `include_bytes!` path has to climb directories (`../../gen/...`). On
+//! Windows this used to be emitted with `\` separators, which are invalid
+//! escape sequences inside the string literal.
+use fluent_typed::{BuildOptions, FtlOutputOptions, try_build_from_locales_folder};
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    let opts = BuildOptions::default()
+        .with_locales_folder("../localization")
+        .with_ftl_output(FtlOutputOptions::single_file("../gen/translations.ftl"))
+        .with_output_file_path("src/l10n.rs");
+    match try_build_from_locales_folder(opts) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("Build failed: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/playground/example2/game/src/lib.rs
+++ b/playground/example2/game/src/lib.rs
@@ -1,0 +1,14 @@
+mod l10n;
+
+pub use l10n::L10n;
+
+#[cfg(test)]
+mod tests {
+    use super::L10n;
+
+    #[test]
+    fn embedded_translations_load() {
+        let en = L10n::En.load();
+        assert_eq!(en.msg_hello_world(), "Hello, world!");
+    }
+}

--- a/playground/example2/localization/en/base.ftl
+++ b/playground/example2/localization/en/base.ftl
@@ -1,0 +1,3 @@
+language-name = English
+
+hello-world = Hello, world!

--- a/playground/example2/localization/fr/base.ftl
+++ b/playground/example2/localization/fr/base.ftl
@@ -1,0 +1,3 @@
+language-name = Français
+
+hello-world = Bonjour, le monde !

--- a/src/build/gen/generated_ftl.rs
+++ b/src/build/gen/generated_ftl.rs
@@ -2,7 +2,7 @@ use std::{
     collections::VecDeque,
     fs, io,
     ops::Range,
-    path::{Path, PathBuf},
+    path::{Component, Path, PathBuf},
 };
 
 use super::StrExt;
@@ -166,12 +166,25 @@ fn relative_path(from_file: &str, to_file: &str) -> io::Result<String> {
     let mut rel_file = relative(&from_dir, &to_dir)?;
     rel_file.push(to_file_name);
 
-    rel_file.to_str().map(|s| s.to_string()).ok_or_else(|| {
-        io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "Could not convert relative path to string",
-        )
-    })
+    to_forward_slashes(&rel_file)
+}
+
+/// Join a relative path's components with `/` regardless of platform.
+///
+/// The result is spliced into `include_bytes!("...")`, where a native Windows
+/// separator would form invalid escape sequences like `\g` (issue #37).
+/// `include_bytes!` accepts forward slashes on every platform.
+fn to_forward_slashes(path: &Path) -> io::Result<String> {
+    let mut parts = Vec::new();
+    for comp in path.components() {
+        parts.push(comp.as_os_str().to_str().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Could not convert relative path to string",
+            )
+        })?);
+    }
+    Ok(parts.join("/"))
 }
 
 fn relative(from_path: &Path, to_path: &Path) -> io::Result<PathBuf> {
@@ -184,6 +197,25 @@ fn relative(from_path: &Path, to_path: &Path) -> io::Result<PathBuf> {
 
     let mut from = from_path.components().collect::<VecDeque<_>>();
     let mut to = to_path.components().collect::<VecDeque<_>>();
+
+    // On Windows two absolute paths can be rooted on different drives, in
+    // which case no relative path between them exists. Without this check the
+    // loop below would emit `..` segments followed by the other drive's
+    // absolute path — garbage that only fails later inside `include_bytes!`.
+    if let (Some(Component::Prefix(from_prefix)), Some(Component::Prefix(to_prefix))) =
+        (from.front(), to.front())
+        && from_prefix != to_prefix
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "No relative path exists between '{}' and '{}' (different drives). \
+                 Place the generated .rs file and the .ftl output on the same drive.",
+                from_path.display(),
+                to_path.display()
+            ),
+        ));
+    }
 
     // Remove common components
     while let (Some(fr_comp), Some(to_comp)) = (from.front(), to.front()) {
@@ -204,8 +236,28 @@ fn relative(from_path: &Path, to_path: &Path) -> io::Result<PathBuf> {
     Ok(relative)
 }
 
-#[test]
-fn test_relative_path() {
-    let rel = relative(Path::new("/a/b/c.rs"), Path::new("/a/d/e.flt")).unwrap();
-    assert_eq!(rel, PathBuf::from("../../d/e.flt"));
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Absolute-path fixtures per platform: `/a/b` is not absolute on Windows.
+    #[cfg(not(windows))]
+    const FIXTURE: (&str, &str) = ("/a/b/c.rs", "/a/d/e.flt");
+    #[cfg(windows)]
+    const FIXTURE: (&str, &str) = (r"C:\a\b\c.rs", r"C:\a\d\e.flt");
+
+    #[test]
+    fn test_relative_path() {
+        let rel = relative(Path::new(FIXTURE.0), Path::new(FIXTURE.1)).unwrap();
+        // Regression for issue #37: the string spliced into `include_bytes!`
+        // must use `/` on every platform, never the native `\`.
+        assert_eq!(to_forward_slashes(&rel).unwrap(), "../../d/e.flt");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_relative_path_across_drives_is_an_error() {
+        let err = relative(Path::new(r"C:\a\b"), Path::new(r"D:\c\d")).unwrap_err();
+        assert!(err.to_string().contains("different drives"), "{err}");
+    }
 }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,4 +1,4 @@
-use std::{io, os::unix::fs::MetadataExt, path::Path, process::Command};
+use std::{io, path::Path, process::Command};
 
 pub fn cargo<I, S>(dir: &Path, args: I)
 where
@@ -48,7 +48,7 @@ pub fn ls_ascii(path: &Path, indent: usize) -> io::Result<String> {
             "{}{} ({} bytes)",
             "  ".repeat(indent),
             file.file_name().unwrap().to_string_lossy(),
-            file.metadata().unwrap().size()
+            file.metadata().unwrap().len()
         ));
     }
 

--- a/tests/playground.rs
+++ b/tests/playground.rs
@@ -46,3 +46,35 @@ fn build_example1() {
         fr.ftl (243 bytes)
     "###);
 }
+
+/// Issue #37: in a workspace, the generated `.rs` and the output `.ftl` live in
+/// different directories, so the `include_bytes!` path has to climb out of
+/// `src/`. On Windows that path was emitted with `\` separators, which are
+/// invalid escape sequences in the string literal and failed the build.
+#[test]
+fn build_example2_workspace() {
+    let root = PathBuf::from("playground/example2");
+    let l10n = root.join("game/src/l10n.rs");
+    if l10n.exists() {
+        fs::remove_file(&l10n).unwrap();
+    }
+    for dir in [root.join("target"), root.join("gen")] {
+        if dir.exists() {
+            fs::remove_dir_all(&dir).unwrap();
+        }
+    }
+
+    cargo(&root, ["test"]);
+
+    let generated = fs::read_to_string(&l10n).unwrap();
+    // The include path must use forward slashes on every platform — `\` would
+    // be an escape sequence inside the literal.
+    assert!(
+        generated.contains(r#"include_bytes!("../../gen/translations.ftl")"#),
+        "expected a forward-slash include path, got: {}",
+        generated
+            .lines()
+            .find(|l| l.contains("include_bytes!"))
+            .unwrap_or("<no include_bytes! line>")
+    );
+}


### PR DESCRIPTION
Fixes #37.

## The bug

On Windows, whenever the generated `.rs` file and the `.ftl` output live in different directories — most visibly a workspace with locales at the workspace root — the generated embed line used native separators:

```rust
static LANG_DATA: &[u8] = include_bytes!("..\..\gen\translations.ftl");
```

`\.` and `\g` are invalid escape sequences, so the build failed inside rustfmt with the opaque `Rustfmt("rustfmt failed")` from the issue report. This also affected the existing non-workspace `playground/example1` (`..\gen\translations.ftl`) — it was never caught because CI only ran on Linux.

## Windows audit

Reproduced on a Windows 11 VM (full `cargo test` sweep plus a workspace repro of the reporter's layout). Four distinct issues confirmed:

1. **`include_bytes!` with `\` separators** (#37) — `relative_path()` in `src/build/gen/generated_ftl.rs` returned the OS-native `PathBuf` string. Fixed by joining the relative path's components with `/` on every platform (`include_bytes!` accepts `/` everywhere).
2. **Test suite didn't compile on Windows** — `tests/common.rs` used the unix-only `os::unix::fs::MetadataExt::size()`. Fixed with the portable `Metadata::len()`.
3. **`test_relative_path` failed on Windows** — its fixtures (`/a/b/c.rs`) aren't absolute paths there. Now uses per-platform fixtures and asserts the forward-slash string form.
4. **CRLF checkouts broke 5 snapshot tests** — with `core.autocrlf=true` (git's Windows default) the `.ftl` fixtures check out as CRLF, shifting every byte range/size baked into the snapshots. Fixed with a `.gitattributes` pinning checkouts to LF (all tracked files are already LF in the index, so this renormalizes nothing).

Also found by inspection: two absolute paths on *different drives* have no relative path, and the old code would emit `..` segments followed by the other drive's absolute path. That now returns a clear build error (with a Windows-only unit test).

## Regression tests

- `playground/example2` — a cargo workspace mirroring the issue's layout (member crate `game/`, `localization/` and `gen/` at the workspace root). `build_example2_workspace` builds it, runs its embedded-loading test, and asserts the generated file contains `include_bytes!("../../gen/translations.ftl")` verbatim.
- `test_relative_path` now checks the forward-slash string on both platforms; `test_relative_path_across_drives_is_an_error` covers the cross-drive case on Windows.
- CI test job now runs on `windows-latest` too, so all of the above actually guard.

## Verification

- Windows 11 VM: `cargo test --features build,langneg` — 104 unit + 3 integration tests, all pass (before: compile failure, then 2 failures once compiling).
- macOS: full suite, clippy `-D warnings`, and fmt all clean.
- Fresh `core.autocrlf=true` clone: fixtures stay LF, all unit tests pass (before: 5 snapshot failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)